### PR TITLE
0.2.0

### DIFF
--- a/src/fat32.rs
+++ b/src/fat32.rs
@@ -10,6 +10,7 @@ use std::{
 const FAT32_IMAGE_SECTOR_COUNT: u64 = 0xFFFF;
 const FAT32_IMAGE_SIZE: u64 = FAT32_IMAGE_SECTOR_COUNT * FAT32_SECTOR_SIZE;
 
+/// Copies a file from the host filesystem into a FAT32 directory.
 fn copy_to_fat<T: Read + Write + Seek>(
     dir: &fatfs::Dir<T>,
     src_path: &Path,
@@ -23,6 +24,7 @@ fn copy_to_fat<T: Read + Write + Seek>(
     Ok(())
 }
 
+/// Creates a FAT32 image file and populates it with the necessary files for UEFI boot.
 pub fn create_fat32_image(path: &Path, bellows_path: &Path, kernel_path: &Path) -> io::Result<()> {
     if path.exists() {
         fs::remove_file(path)?;
@@ -47,7 +49,7 @@ pub fn create_fat32_image(path: &Path, bellows_path: &Path, kernel_path: &Path) 
 
         copy_to_fat(&boot_dir, bellows_path, "BOOTX64.EFI")?;
         copy_to_fat(&boot_dir, kernel_path, "KERNEL.EFI")?;
-    } // `fs`, `root`, `efi_dir`, `boot_dir` are dropped here, releasing the mutable borrow on `file`.
+    }
 
     file.sync_all()?;
 

--- a/src/iso.rs
+++ b/src/iso.rs
@@ -1,4 +1,5 @@
 // isobemak/src/iso.rs
+// ISO + El Torito
 use crate::utils::{FAT32_SECTOR_SIZE, ISO_SECTOR_SIZE};
 use fatfs::{self, FsOptions};
 use std::{
@@ -15,6 +16,8 @@ const ISO_ID: &[u8] = b"CD001";
 const ISO_VERSION: u8 = 1;
 const PVD_VOLUME_ID_OFFSET: usize = 40;
 const PVD_TOTAL_SECTORS_OFFSET: usize = 80;
+
+// New constants for PVD fields
 const PVD_VOL_SET_SIZE_OFFSET: usize = 120;
 const PVD_VOL_SEQ_NUM_OFFSET: usize = 124;
 const PVD_LOGICAL_BLOCK_SIZE_OFFSET: usize = 128;
@@ -27,6 +30,8 @@ const BOOT_CATALOG_VALIDATION_ENTRY_HEADER_ID: u8 = 1;
 const BOOT_CATALOG_BOOT_ENTRY_HEADER_ID: u8 = 0x88;
 const BOOT_CATALOG_NO_EMULATION: u8 = 0x00;
 const BOOT_CATALOG_EFI_PLATFORM_ID: u8 = 0xEF;
+
+// New constants for Boot Catalog
 const ID_FIELD_OFFSET: usize = 4;
 const ID_FIELD_LEN: usize = 24;
 const ID_STR: &[u8] = b"ISOBEMAKI EFI BOOT";
@@ -62,14 +67,7 @@ fn write_directory_record(
     file_id: &[u8],
     flags: u8,
 ) {
-    let record_len = DIR_RECORD_LEN as usize + file_id.len();
-    let padded_len = if record_len % 2 == 0 {
-        record_len
-    } else {
-        record_len + 1
-    };
-
-    sector[offset] = padded_len as u8;
+    sector[offset] = DIR_RECORD_LEN;
     sector[offset + DIR_RECORD_LBA_OFFSET..offset + DIR_RECORD_LBA_OFFSET + 4]
         .copy_from_slice(&lba.to_le_bytes());
     sector[offset + DIR_RECORD_LBA_OFFSET + 4..offset + DIR_RECORD_LBA_OFFSET + 8]
@@ -80,7 +78,7 @@ fn write_directory_record(
     sector[offset + DIR_RECORD_DATA_LEN_OFFSET + 4..offset + DIR_RECORD_DATA_LEN_OFFSET + 8]
         .copy_from_slice(&data_len.to_be_bytes());
 
-    sector[offset + DIR_RECORD_FLAGS_OFFSET] = flags;
+    sector[offset + DIR_RECORD_FLAGS_OFFSET] = flags; // File flags
     let vol_seq: u16 = 1;
     sector[offset + DIR_RECORD_VOL_SEQ_OFFSET..offset + DIR_RECORD_VOL_SEQ_OFFSET + 2]
         .copy_from_slice(&vol_seq.to_le_bytes());
@@ -90,6 +88,34 @@ fn write_directory_record(
     sector[offset + DIR_RECORD_ID_LEN_OFFSET] = file_id.len() as u8;
     sector[offset + DIR_RECORD_ID_OFFSET..offset + DIR_RECORD_ID_OFFSET + file_id.len()]
         .copy_from_slice(file_id);
+}
+
+fn write_root_directory_sector(iso: &mut File, root_dir_lba: u32) -> io::Result<()> {
+    pad_to_lba(iso, root_dir_lba)?;
+    let mut root_dir_sector = [0u8; ISO_SECTOR_SIZE];
+
+    // . (self) directory record
+    write_directory_record(
+        &mut root_dir_sector,
+        0,
+        root_dir_lba,
+        ISO_SECTOR_SIZE as u32,
+        b"\x00",
+        2,
+    );
+
+    // .. (parent) directory record
+    let parent_offset = DIR_RECORD_LEN as usize;
+    write_directory_record(
+        &mut root_dir_sector,
+        parent_offset,
+        root_dir_lba,
+        ISO_SECTOR_SIZE as u32,
+        b"\x01",
+        2,
+    );
+
+    iso.write_all(&root_dir_sector)
 }
 
 fn write_primary_volume_descriptor(
@@ -138,7 +164,7 @@ fn write_primary_volume_descriptor(
         .copy_from_slice(&path_table_size.to_be_bytes());
 
     let mut root_dir_record = [0u8; 34];
-    root_dir_record[0] = 34;
+    root_dir_record[0] = 34; // Directory record length
     let root_dir_lba_u32 = root_dir_lba;
     root_dir_record[2..6].copy_from_slice(&root_dir_lba_u32.to_le_bytes());
     root_dir_record[6..10].copy_from_slice(&root_dir_lba_u32.to_be_bytes());
@@ -166,7 +192,7 @@ fn write_boot_record_volume_descriptor(iso: &mut File, lba_boot_catalog: u32) ->
     brvd[6] = ISO_VERSION;
     let spec_name = b"EL TORITO SPECIFICATION";
     brvd[7..7 + spec_name.len()].copy_from_slice(spec_name);
-    brvd[71..75].copy_from_slice(&lba_boot_catalog.to_le_bytes());
+    brvd[71..75].copy_from_slice(&lba_boot_catalog.to_le_bytes()); // Boot Catalog LBA
     iso.write_all(&brvd)
 }
 
@@ -185,9 +211,10 @@ fn write_boot_catalog(iso: &mut File, fat_image_lba: u32, img_file_size: u64) ->
     pad_to_lba(iso, LBA_BOOT_CATALOG)?;
     let mut cat = [0u8; ISO_SECTOR_SIZE];
 
+    // Validation Entry
     cat[0] = BOOT_CATALOG_VALIDATION_ENTRY_HEADER_ID;
     cat[1] = BOOT_CATALOG_EFI_PLATFORM_ID;
-    cat[2..4].copy_from_slice(&[0; 2]);
+    cat[2..4].copy_from_slice(&[0; 2]); // Reserved
 
     let mut id_field = [0u8; ID_FIELD_LEN];
     id_field[..ID_STR.len()].copy_from_slice(ID_STR);
@@ -196,6 +223,7 @@ fn write_boot_catalog(iso: &mut File, fat_image_lba: u32, img_file_size: u64) ->
     cat[BOOT_CATALOG_VALIDATION_SIGNATURE_OFFSET..BOOT_CATALOG_VALIDATION_SIGNATURE_OFFSET + 2]
         .copy_from_slice(&BOOT_CATALOG_HEADER_SIGNATURE.to_le_bytes());
 
+    // Checksum calculation (reordered)
     let mut sum: u16 = 0;
     for i in (0..32).step_by(2) {
         sum = sum.wrapping_add(u16::from_le_bytes([cat[i], cat[i + 1]]));
@@ -204,10 +232,12 @@ fn write_boot_catalog(iso: &mut File, fat_image_lba: u32, img_file_size: u64) ->
     cat[BOOT_CATALOG_CHECKSUM_OFFSET..BOOT_CATALOG_CHECKSUM_OFFSET + 2]
         .copy_from_slice(&checksum.to_le_bytes());
 
+    // Boot Entry
     let mut entry = [0u8; 32];
     entry[0] = BOOT_CATALOG_BOOT_ENTRY_HEADER_ID;
     entry[1] = BOOT_CATALOG_NO_EMULATION;
 
+    // FIX: Write the correct sector count in FAT32_SECTOR_SIZE (512-byte) units
     let sector_count_512 = img_file_size.div_ceil(FAT32_SECTOR_SIZE);
     let sector_count_u16 = if sector_count_512 > 0xFFFF {
         0xFFFF
@@ -216,7 +246,7 @@ fn write_boot_catalog(iso: &mut File, fat_image_lba: u32, img_file_size: u64) ->
     };
     entry[6..8].copy_from_slice(&sector_count_u16.to_le_bytes());
 
-    entry[8..12].copy_from_slice(&fat_image_lba.to_le_bytes());
+    entry[8..12].copy_from_slice(&fat_image_lba.to_le_bytes()); // LBA of FAT32 image
     cat[32..64].copy_from_slice(&entry);
 
     iso.write_all(&cat)
@@ -307,7 +337,7 @@ fn copy_fat_dir_to_iso(
             write_directory_record(&mut dir_sector, offset, entry_lba, entry_size, &name_iso, 2);
         } else {
             let mut file = entry.to_file();
-            let file_size = file.len()?;
+            let file_size = entry.len();
             let file_lba = (iso.stream_position()? / ISO_SECTOR_SIZE as u64) as u32;
             io::copy(&mut file, iso)?;
             pad_to_lba(
@@ -348,7 +378,7 @@ pub fn create_iso_from_img(iso_path: &Path, img_path: &Path) -> io::Result<()> {
     io::copy(
         &mut io::repeat(0).take(ISO_SECTOR_SIZE as u64 * 16),
         &mut iso,
-    )?;
+    )?; // System Area
 
     const FAT_IMAGE_LBA: u32 = 21;
     let root_dir_lba;
@@ -361,24 +391,32 @@ pub fn create_iso_from_img(iso_path: &Path, img_path: &Path) -> io::Result<()> {
         root_dir_lba = copy_fat_dir_to_iso(&mut iso, &root, 20)?;
     }
 
-    // Now that we know the root dir LBA, we can write the PVD
-    write_primary_volume_descriptor(&mut iso, 0, root_dir_lba)?;
-    const LBA_BOOT_CATALOG: u32 = 19;
-    write_boot_record_volume_descriptor(&mut iso, LBA_BOOT_CATALOG)?;
-    write_volume_descriptor_terminator(&mut iso)?;
-
-    write_boot_catalog(&mut iso, FAT_IMAGE_LBA, img_file_size)?;
-
+    // Write FAT image
     pad_to_lba(&mut iso, FAT_IMAGE_LBA)?;
     img_file.seek(SeekFrom::Start(0))?;
     let mut limited_reader = img_file.take(img_file_size);
     io::copy(&mut limited_reader, &mut iso)?;
 
+    // Calculate the final total sectors from the actual file size
     let final_pos = iso.stream_position()?;
     let total_sectors = final_pos.div_ceil(ISO_SECTOR_SIZE as u64) as u32;
 
+    // Write ISO Volume Descriptors
+    write_primary_volume_descriptor(&mut iso, total_sectors, root_dir_lba)?;
+    const LBA_BOOT_CATALOG: u32 = 19;
+    write_boot_record_volume_descriptor(&mut iso, LBA_BOOT_CATALOG)?;
+    write_volume_descriptor_terminator(&mut iso)?;
+
+    // Write Boot Catalog
+    write_boot_catalog(&mut iso, FAT_IMAGE_LBA, img_file_size)?;
+
+    // Write Root Directory Sector
+    write_root_directory_sector(&mut iso, root_dir_lba)?;
+
+    // Seek back and update the total_sectors field in the PVD
     update_total_sectors(&mut iso, total_sectors)?;
 
+    // Ensure the file is truncated to the correct size
     iso.set_len(total_sectors as u64 * ISO_SECTOR_SIZE as u64)?;
 
     Ok(())

--- a/src/iso.rs
+++ b/src/iso.rs
@@ -343,7 +343,7 @@ fn write_boot_catalog(iso: &mut File, bootx64_lba: u32, bootx64_size: u32) -> io
     entry[1] = BOOT_CATALOG_NO_EMULATION;
 
     // Calculate the number of 512-byte sectors for BOOTX64.EFI
-    let sector_count_512 = (bootx64_size as u64).div_ceil(512);
+    let sector_count_512 = (bootx64_size as u64).div_ceil(FAT32_SECTOR_SIZE);
     let sector_count_u16 = if sector_count_512 > 0xFFFF {
         0xFFFF
     } else {

--- a/src/iso.rs
+++ b/src/iso.rs
@@ -70,7 +70,7 @@ fn write_directory_record(
     file_id: &[u8],
 ) {
     let id_len = file_id.len() as u8;
-    let rec_len = DIR_RECORD_LEN_MIN + id_len + (id_len % 2);
+    let rec_len = 33 + id_len + (id_len + 1) % 2;
 
     if *offset + rec_len as usize > ISO_SECTOR_SIZE {
         return;

--- a/src/iso.rs
+++ b/src/iso.rs
@@ -73,8 +73,7 @@ fn write_directory_record(
     let rec_len = 33 + id_len + (id_len + 1) % 2;
 
     if *offset + rec_len as usize > sector.len() {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
+        return Err(std::io::Error::other(
             "sector overflow when writing directory record",
         ));
     }

--- a/src/iso.rs
+++ b/src/iso.rs
@@ -1,6 +1,6 @@
 // isobemak/src/iso.rs
 // ISO + El Torito
-use crate::utils::ISO_SECTOR_SIZE;
+use crate::utils::{FAT32_SECTOR_SIZE, ISO_SECTOR_SIZE};
 use std::{
     fs::File,
     io::{self, Read, Seek, SeekFrom, Write},

--- a/src/iso.rs
+++ b/src/iso.rs
@@ -72,9 +72,10 @@ fn write_directory_record(
     let id_len = file_id.len() as u8;
     let rec_len = 33 + id_len + (id_len + 1) % 2;
 
-    if *offset + rec_len as usize > ISO_SECTOR_SIZE {
-        return;
-    }
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            "sector overflow when writing directory record",
+        ));
 
     let record_slice = &mut sector[*offset..];
     record_slice[0] = rec_len;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,6 @@ pub fn create_disk_and_iso(
     kernel_path: &Path,
 ) -> io::Result<()> {
     create_fat32_image(fat32_img_path, bellows_path, kernel_path)?;
-    create_iso_from_img(&iso_path, &efi_path)?;
+    create_iso_from_img(iso_path, efi_path)?;
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ mod utils;
 
 /// High-level function to create the FAT32 image and then the final ISO.
 pub fn create_disk_and_iso(
+    fat32_img_path: &Path,
     efi_path: &Path,
     iso_path: &Path,
     bellows_path: &Path,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ mod fat32;
 mod iso;
 mod utils;
 
+/// High-level function to create the FAT32 image and then the final ISO.
 pub fn create_disk_and_iso(
     fat32_img_path: &Path,
     iso_path: &Path,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,11 +10,8 @@ mod utils;
 
 /// High-level function to create the FAT32 image and then the final ISO.
 pub fn create_disk_and_iso(
-    fat32_img_path: &Path,
-    efi_path: &Path,
     iso_path: &Path,
-    bellows_path: &Path,
-    kernel_path: &Path,
+    efi_path: &Path,
 ) -> io::Result<()> {
     // create_fat32_image(fat32_img_path, bellows_path, kernel_path)?;
     create_iso_from_img(iso_path, efi_path)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ pub fn create_disk_and_iso(
     bellows_path: &Path,
     kernel_path: &Path,
 ) -> io::Result<()> {
-    create_fat32_image(fat32_img_path, bellows_path, kernel_path)?;
+    // create_fat32_image(fat32_img_path, bellows_path, kernel_path)?;
     create_iso_from_img(iso_path, efi_path)?;
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,10 +9,7 @@ mod iso;
 mod utils;
 
 /// High-level function to create the FAT32 image and then the final ISO.
-pub fn create_disk_and_iso(
-    iso_path: &Path,
-    efi_path: &Path,
-) -> io::Result<()> {
+pub fn create_disk_and_iso(iso_path: &Path, efi_path: &Path) -> io::Result<()> {
     // create_fat32_image(fat32_img_path, bellows_path, kernel_path)?;
     create_iso_from_img(iso_path, efi_path)?;
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,12 +10,12 @@ mod utils;
 
 /// High-level function to create the FAT32 image and then the final ISO.
 pub fn create_disk_and_iso(
-    fat32_img_path: &Path,
+    efi_path: &Path,
     iso_path: &Path,
     bellows_path: &Path,
     kernel_path: &Path,
 ) -> io::Result<()> {
     create_fat32_image(fat32_img_path, bellows_path, kernel_path)?;
-    create_iso_from_img(iso_path, fat32_img_path)?;
+    create_iso_from_img(&iso_path, &efi_path)?;
     Ok(())
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,6 +7,7 @@ use std::{
 pub const ISO_SECTOR_SIZE: usize = 2048;
 pub const FAT32_SECTOR_SIZE: u64 = 512;
 
+/// Pads a file with zeros to align to the ISO sector size.
 pub fn pad_sector(f: &mut File) -> io::Result<()> {
     let pos = f.stream_position()?;
     let pad = ISO_SECTOR_SIZE as u64 - (pos % ISO_SECTOR_SIZE as u64);


### PR DESCRIPTION
# Pull Request

## Overview

<!-- Describe the issue that this PR solves and its purpose. -->
- Response details: Implement actual works iso file

## Change details

- [x] New feature
- [x] Refactoring
- [x] Bug fix
- [ ] CI / Build settings correction
- [ ] Documentation update

## Build / Test Results

```sh
$ cargo check     # ✅
$ cargo test      # ✅
```

## Others

<!-- Notes for reviewers -->
```sh
placeless@DESKTOP-EUKE557:~/fullerene$ isoinfo -d -i fullerene.iso
CD-ROM is in ISO 9660 format
System id: 
Volume id: ISOBEMAKI
Volume set id: 
Publisher id: 
Data preparer id: 
Application id: 
Copyright File id: 
Abstract File id: 
Bibliographic File id: 
Volume set size is: 1
Volume set sequence number is: 1
Logical block size is: 2048
Volume size is: 16407
El Torito VD version 1 found, boot catalog is in sector 19
NO Joliet present
NO Rock Ridge present
Eltorito validation header:
    Hid 1
    Arch 239 (Unknown Arch)
    ID 'ISOBEMAKI EFI BOOT'
    Key 55 AA
    Eltorito defaultboot header:
        Bootid 88 (bootable)
        Boot media 0 (No Emulation Boot)
        Load segment 0
        Sys type 0
        Nsect FFFFFFFF
        Bootoff 17 23
placeless@DESKTOP-EUKE557:~/fullerene$ 7z l fullerene.iso

7-Zip 23.01 (x64) : Copyright (c) 1999-2023 Igor Pavlov : 2023-06-20
 64-bit locale=C.UTF-8 Threads:8 OPEN_MAX:1048576

Scanning the drive for archives:
1 file, 33601536 bytes (33 MiB)

Listing archive: fullerene.iso

--
Path = fullerene.iso
Type = Iso
Physical Size = 33601536
Comment = 
{

Volume: ISOBEMAKI
}

   Date      Time    Attr         Size   Compressed  Name
------------------- ----- ------------ ------------  ------------------------
                    D....                            EFI
                    D....                            EFI/BOOT
                    .....     33553920     33553920  EFI/BOOT/BOOTX64.EFI
                    .....     33553920     33553920  [BOOT]/Boot-NoEmul.img
------------------- ----- ------------ ------------  ------------------------
                              67107840     67107840  2 files, 2 folders
placeless@DESKTOP-EUKE557:~/fullerene$ dumpet -i fullerene.iso
Validation Entry:
        Header Indicator: 0x01 (Validation Entry)
        PlatformId: 0xef (EFI)
        ID: "ISOBEMAKI EFI BOOT"
        Checksum: 0x0e24
        Key bytes: 0x55aa
Boot Catalog Default Entry:
        Entry is bootable
        Boot Media emulation type: no emulation
        Media load address: 0 (0x0000)
        System type: 0 (0x00)
        Load Sectors: 65535 (0xffff)
        Load LBA: 23 (0x00000017)
```
---