### PR TITLE
Update docs

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,26 +1,30 @@
 # API Documentation
 
-This document outlines the API endpoints and their usage for creating bootable ISO 9660 images with UEFI support.
+This document outlines the API for `isobemak`, a Rust crate for creating bootable ISO 9660 images with UEFI and BIOS support.
 
-## Core Functionality
+## Main Functions
 
-The primary function for creating ISO images is `build_iso`.
+### `build_iso(iso_path: &Path, image: &IsoImage, is_isohybrid: bool) -> io::Result<(PathBuf, Option<NamedTempFile>, File, Option<u32>)>`
 
-### `build_iso(output_path: &Path, iso_image: &IsoImage) -> io::Result<()>`
-
-**Description:** Builds a bootable ISO 9660 image at the specified `output_path` using the provided `iso_image` configuration.
+**Description:** Builds a bootable ISO 9660 image at the specified path. For hybrid isohybrid images that can boot from both optical media and USB drives, set `is_isohybrid` to `true`.
 
 **Parameters:**
-- `output_path`: The path where the ISO image will be created.
-- `iso_image`: A configuration object defining the files and boot information for the ISO image.
+- `iso_path`: The path where the ISO image will be created
+- `image`: Configuration object defining the files and boot information for the ISO image
+- `is_isohybrid`: Whether to create a hybrid isohybrid image that can boot from USB drives
+
+**Returns:**
+A tuple containing:
+- `PathBuf`: The path to the created ISO file
+- `Option<NamedTempFile>`: Temporary FAT image file (if created for isohybrid)
+- `File`: Open file handle to the ISO
+- `Option<u32>`: FAT image size in 512-byte sectors (if created)
 
 ## Configuration Structures
 
-The `IsoImage` struct and its related structs define the configuration for the ISO image.
-
 ### `IsoImage`
 
-Represents the overall configuration for an ISO image.
+Top-level configuration structure for ISO images.
 
 ```rust
 pub struct IsoImage {
@@ -31,7 +35,7 @@ pub struct IsoImage {
 
 ### `IsoImageFile`
 
-Represents a file to be included in the ISO image.
+Represents a file to be included in the ISO.
 
 ```rust
 pub struct IsoImageFile {
@@ -42,7 +46,7 @@ pub struct IsoImageFile {
 
 ### `BootInfo`
 
-Contains information for both BIOS and UEFI booting.
+Contains boot configuration for BIOS and/or UEFI booting.
 
 ```rust
 pub struct BootInfo {
@@ -53,7 +57,7 @@ pub struct BootInfo {
 
 ### `BiosBootInfo`
 
-Configuration for BIOS booting.
+Configuration for BIOS/El Torito boot support.
 
 ```rust
 pub struct BiosBootInfo {
@@ -65,59 +69,186 @@ pub struct BiosBootInfo {
 
 ### `UefiBootInfo`
 
-Configuration for UEFI booting.
+Configuration for UEFI booting. For isohybrid images, this will create an EFI System Partition with the specified boot and kernel images.
 
 ```rust
 pub struct UefiBootInfo {
     pub boot_image: PathBuf,
+    pub kernel_image: PathBuf,
     pub destination_in_iso: String,
 }
 ```
 
-## Example Usage
+## Builder API
+
+### `IsoBuilder`
+
+Provides a builder pattern interface for more advanced ISO creation.
 
 ```rust
-use isobemak::iso::builder::{build_iso, IsoImage, IsoImageFile, BootInfo, BiosBootInfo, UefiBootInfo};
-use std::path::PathBuf;
-use std::io;
+pub struct IsoBuilder { /* ... */ }
+```
 
-fn main() -> io::Result<()> {
-    let isolinux_bin_path = PathBuf::from("path/to/isolinux.bin");
-    let kernel_path = PathBuf::from("path/to/kernel");
-    let initrd_img_path = PathBuf::from("path/to/initrd.img");
-    let iso_output_path = PathBuf::from("my_bootable.iso");
+**Methods:**
+- `new() -> Self`: Creates a new builder
+- `add_file(&mut self, path_in_iso: &str, real_path: PathBuf) -> io::Result<()>`: Adds a file to the ISO
+- `set_boot_info(&mut self, boot_info: BootInfo)`: Sets boot configuration
+- `set_isohybrid(&mut self, is_isohybrid: bool)`: Enables hybrid isohybrid creation
+- `build(&mut self, iso_file: &mut File, iso_path: &Path, esp_lba: Option<u32>, esp_size_sectors: Option<u32>) -> io::Result<()>`: Builds the ISO
 
-    let iso_image = IsoImage {
-        files: vec![
-            IsoImageFile {
-                source: isolinux_bin_path.clone(),
-                destination: "isolinux/isolinux.bin".to_string(),
-            },
-            IsoImageFile {
-                source: kernel_path.clone(),
-                destination: "kernel".to_string(),
-            },
-            IsoImageFile {
-                source: initrd_img_path.clone(),
-                destination: "initrd.img".to_string(),
-            },
-        ],
-        boot_info: BootInfo {
-            bios_boot: Some(BiosBootInfo {
-                boot_catalog: PathBuf::from("BOOT.CAT"),
-                boot_image: isolinux_bin_path,
-                destination_in_iso: "isolinux/isolinux.bin".to_string(),
-            }),
-            uefi_boot: Some(UefiBootInfo {
-                boot_image: PathBuf::from("path/to/BOOTX64.EFI"),
-                destination_in_iso: "EFI/BOOT/EFI.img".to_string(),
-            }),
-        },
-    };
+## Filesystem Nodes
 
-    build_iso(&iso_output_path, &iso_image)?;
+### `IsoFsNode`
 
-    println!("ISO image created successfully at: {:?}", iso_output_path);
+Represents a filesystem node in the ISO.
 
-    Ok(())
+```rust
+pub enum IsoFsNode {
+    File(IsoFile),
+    Directory(IsoDirectory),
 }
+```
+
+### `IsoFile`
+
+Represents a file in the ISO filesystem.
+
+```rust
+pub struct IsoFile {
+    pub path: PathBuf,
+    pub size: u64,
+    pub lba: u32,
+}
+```
+
+### `IsoDirectory`
+
+Represents a directory in the ISO filesystem.
+
+```rust
+pub struct IsoDirectory {
+    pub lba: u32,
+    pub children: HashMap<String, IsoFsNode>,
+}
+```
+
+## Constants
+
+### `ESP_START_LBA`
+
+The Logical Block Address where the EFI System Partition starts in hybrid isohybrid images.
+
+```rust
+pub const ESP_START_LBA: u32 = 34;
+```
+
+## Examples
+
+### Basic UEFI-Bootable ISO
+
+```rust
+use isobemak::{build_iso, IsoImage, IsoImageFile, BootInfo, UefiBootInfo};
+use std::path::PathBuf;
+
+let kernel_path = PathBuf::from("path/to/kernel");
+let bootx64_efi_path = PathBuf::from("path/to/BOOTX64.EFI");
+let iso_output_path = PathBuf::from("bootable.iso");
+
+let iso_image = IsoImage {
+    files: vec![
+        IsoImageFile {
+            source: kernel_path.clone(),
+            destination: "kernel".to_string(),
+        },
+    ],
+    boot_info: BootInfo {
+        bios_boot: None,
+        uefi_boot: Some(UefiBootInfo {
+            boot_image: bootx64_efi_path.clone(),
+            kernel_image: kernel_path.clone(),
+            destination_in_iso: "EFI/BOOT/BOOTX64.EFI".to_string(),
+        }),
+    },
+};
+
+// Create standard UEFI-bootable ISO
+let (_iso_path, _temp_fat, _iso_file, _fat_size) = build_iso(&iso_output_path, &iso_image, false)?;
+```
+
+### Hybrid Isohybrid ISO (BIOS + UEFI)
+
+```rust
+use isobemak::{build_iso, IsoImage, IsoImageFile, BootInfo, BiosBootInfo, UefiBootInfo};
+use std::path::PathBuf;
+
+let isolinux_bin_path = PathBuf::from("path/to/isolinux.bin");
+let kernel_path = PathBuf::from("path/to/kernel");
+let bootx64_efi_path = PathBuf::from("path/to/BOOTX64.EFI");
+let iso_output_path = PathBuf::from("hybrid.iso");
+
+let iso_image = IsoImage {
+    files: vec![
+        IsoImageFile {
+            source: kernel_path.clone(),
+            destination: "kernel".to_string(),
+        },
+    ],
+    boot_info: BootInfo {
+        bios_boot: Some(BiosBootInfo {
+            boot_catalog: PathBuf::from("BOOT.CAT"),
+            boot_image: isolinux_bin_path.clone(),
+            destination_in_iso: "isolinux/isolinux.bin".to_string(),
+        }),
+        uefi_boot: Some(UefiBootInfo {
+            boot_image: bootx64_efi_path.clone(),
+            kernel_image: kernel_path.clone(),
+            destination_in_iso: "EFI/BOOT/BOOTX64.EFI".to_string(),
+        }),
+    },
+};
+
+// Create hybrid isohybrid ISO
+let (_iso_path, _temp_fat, _iso_file, _fat_size) = build_iso(&iso_output_path, &iso_image, true)?;
+```
+
+### Using the Builder Pattern
+
+```rust
+use isobemak::{IsoBuilder, BootInfo, BiosBootInfo, UefiBootInfo};
+use std::fs::File;
+use std::path::PathBuf;
+
+let mut builder = IsoBuilder::new();
+builder.set_isohybrid(true);
+
+builder.add_file("kernel", PathBuf::from("my_kernel"))?;
+builder.add_file("initrd.img", PathBuf::from("my_initrd"))?;
+
+let boot_info = BootInfo {
+    bios_boot: Some(BiosBootInfo {
+        boot_catalog: PathBuf::from("BOOT.CAT"),
+        boot_image: PathBuf::from("isolinux.bin"),
+        destination_in_iso: "isolinux/isolinux.bin".to_string(),
+    }),
+    uefi_boot: Some(UefiBootInfo {
+        boot_image: PathBuf::from("BOOTX64.EFI"),
+        kernel_image: PathBuf::from("kernel"),
+        destination_in_iso: "EFI/BOOT/BOOTX64.EFI".to_string(),
+    }),
+};
+
+builder.set_boot_info(boot_info);
+
+let mut iso_file = File::create("output.iso")?;
+builder.build(&mut iso_file, Path::new("output.iso"), None, None)?;
+```
+
+## Error Handling
+
+All functions return `io::Result<T>`, so handle `std::io::Error` for file I/O and validation errors.
+
+Common errors:
+- Invalid file paths
+- Insufficient disk space
+- Unsupported image sizes for hybrid ISOs (minimum 69 sectors)
+- Missing boot files

--- a/README.md
+++ b/README.md
@@ -1,39 +1,186 @@
-<div align="center">
-  <h1>isobemak</h1>
-</div>
+# isobemak
 
-**isobemak** is a Rust crate designed to create bootable disk images. It's built for generating an ISO file that contains a FAT32 filesystem, tailored for UEFI booting.
+**isobemak** is a Rust crate for creating bootable ISO 9660 images with UEFI and BIOS support. It can generate standard ISO images or hybrid isohybrid images that can boot from both optical media and USB drives.
 
-## How it works
+## Features
 
-The crate handles two main tasks to produce a bootable ISO:
+- **ISO 9660 Filesystem Creation**: Generates standard ISO 9660 filesystem structures
+- **UEFI Boot Support**: Creates UEFI-bootable images with proper ESP (EFI System Partition) handling
+- **BIOS/El Torito Boot Support**: Provides legacy BIOS boot capability
+- **Hybrid Isohybrid Images**: Generates hybrid images that can boot both as optical media and USB drives with GPT/MBR structures
+- **FAT32 ESP Creation**: Automatically creates FAT32-formatted EFI System Partitions for UEFI booting
 
-1.  **Creating a FAT32 Disk Image**: It creates a new file, sizes it to 32 MiB, and formats it as FAT32. The crate then copies two essential files, a bootloader and a kernel, into the `EFI/BOOT/` directory inside this image. It renames the bootloader to `BOOTX64.EFI` and the kernel to `KERNEL.EFI`, a standard convention for UEFI booting.
+## Installation
 
-2.  **Generating the ISO File**: The crate creates a new ISO file and populates it with the necessary data structures to make it bootable according to the El Torito standard. This includes:
+Add this to your `Cargo.toml`:
 
-      * A **Primary Volume Descriptor** with information like the volume ID "FULLERENE" and the total number of sectors.
-      * A **Boot Record Volume Descriptor** that identifies the image as an El Torito bootable specification.
-      * A **Boot Catalog** which specifies the location and size of the boot image.
-
-The FAT32 disk image created in the first step is then added to the ISO at a specific location (LBA 20), making it the bootable payload for the ISO.
-
-## Project Structure
-
-  * `src/lib.rs`: The main entry point that coordinates the creation of both the FAT32 image and the final ISO file.
-  * `src/fat32.rs`: Contains the logic for creating and formatting the 32 MiB FAT32 disk image and copying the bootloader and kernel files into it.
-  * `src/iso.rs`: Handles the creation of the ISO9660 filesystem with El Torito bootable extensions. It sets up the various volume descriptors and the boot catalog.
-  * `src/utils.rs`: Provides utility functions, such as `pad_sector`, which aligns files to the correct sector size (2048 bytes).
+```toml
+[dependencies]
+isobemak = "0.2.2"
+```
 
 ## Usage
 
-The `create_disk_and_iso` function in `src/lib.rs` is the primary function to be used. It takes the paths for the output FAT32 and ISO images, as well as file handles for the bootloader and the kernel.
+The primary function is `build_iso`, which takes a configured `IsoImage` and generates the ISO file.
 
-```ignore
-pub fn create_disk_and_iso(
-    fat32_img: &Path,
-    iso: &Path,
-    bellows: &mut File,
-    kernel: &mut File,
-) -> io::Result<()>
+### Basic Example
+
+```rust
+use isobemak::{build_iso, IsoImage, IsoImageFile, BootInfo, UefiBootInfo};
+use std::path::PathBuf;
+
+let isolinux_bin_path = PathBuf::from("path/to/isolinux.bin");
+let kernel_path = PathBuf::from("path/to/kernel");
+let bootx64_efi_path = PathBuf::from("path/to/BOOTX64.EFI");
+let iso_output_path = PathBuf::from("bootable.iso");
+
+let iso_image = IsoImage {
+    files: vec![
+        IsoImageFile {
+            source: kernel_path.clone(),
+            destination: "kernel".to_string(),
+        },
+    ],
+    boot_info: BootInfo {
+        bios_boot: None,
+        uefi_boot: Some(UefiBootInfo {
+            boot_image: bootx64_efi_path.clone(),
+            kernel_image: kernel_path.clone(),
+            destination_in_iso: "EFI/BOOT/BOOTX64.EFI".to_string(),
+        }),
+    },
+};
+
+// Create a standard UEFI-bootable ISO
+let (iso_path, _temp_fat, _iso_file, _fat_size) = build_iso(&iso_output_path, &iso_image, false)?;
 ```
+
+### Hybrid Isohybrid Example
+
+```rust
+use isobemak::{build_iso, IsoImage, IsoImageFile, BootInfo, BiosBootInfo, UefiBootInfo};
+use std::path::PathBuf;
+
+let isolinux_bin_path = PathBuf::from("path/to/isolinux.bin");
+let kernel_path = PathBuf::from("path/to/kernel");
+let bootx64_efi_path = PathBuf::from("path/to/BOOTX64.EFI");
+let iso_output_path = PathBuf::from("hybrid.iso");
+
+let iso_image = IsoImage {
+    files: vec![
+        IsoImageFile {
+            source: kernel_path.clone(),
+            destination: "kernel".to_string(),
+        },
+    ],
+    boot_info: BootInfo {
+        bios_boot: Some(BiosBootInfo {
+            boot_catalog: PathBuf::from("BOOT.CAT"),
+            boot_image: isolinux_bin_path.clone(),
+            destination_in_iso: "isolinux/isolinux.bin".to_string(),
+        }),
+        uefi_boot: Some(UefiBootInfo {
+            boot_image: bootx64_efi_path.clone(),
+            kernel_image: kernel_path.clone(),
+            destination_in_iso: "EFI/BOOT/BOOTX64.EFI".to_string(),
+        }),
+    },
+};
+
+// Create a hybrid isohybrid ISO that can boot from both CD/DVD and USB
+let (iso_path, _temp_fat, _iso_file, _fat_size) = build_iso(&iso_output_path, &iso_image, true)?;
+```
+
+## How It Works
+
+### Standard ISO Creation
+
+1. **Filesystem Preparation**: Creates an ISO 9660 filesystem structure with directories and file records
+2. **Boot Catalog Creation**: Generates an El Torito boot catalog pointing to boot images
+3. **Volume Descriptors**: Writes Primary Volume Descriptor, Boot Record Volume Descriptor, and Volume Descriptor Set Terminator
+4. **File Copying**: Copies all specified files into the ISO at their designated locations
+
+### Isohybrid (Hybrid) Creation
+
+For hybrid images, the process additionally includes:
+
+1. **EFI System Partition Creation**: Generates a FAT32-formatted disk image containing the UEFI bootloader and kernel
+2. **ESP Embedding**: Embeds the EFI System Partition into the ISO at a specific location (LBA 34)
+3. **MBR/GPT Structures**: Adds Master Boot Record and GUID Partition Table structures to make the image USB-bootable
+4. **Hybrid Boot Catalog**: Creates boot catalog entries for both BIOS (MBR) and UEFI (ESP) booting
+
+## API Overview
+
+### Core Functions
+
+- `build_iso(iso_path: &Path, image: &IsoImage, is_isohybrid: bool)` - Main ISO creation function
+
+### Configuration Structures
+
+- `IsoImage` - Top-level configuration containing files and boot information
+- `IsoImageFile` - Specifies source file and destination path in ISO
+- `BootInfo` - Contains optional BIOS and UEFI boot configurations
+- `BiosBootInfo` - BIOS/El Torito boot settings
+- `UefiBootInfo` - UEFI boot settings including ESP creation
+
+### Builder Pattern Alternative
+
+For more control, you can use the `IsoBuilder`:
+
+```rust
+use isobemak::{IsoBuilder, BootInfo, BiosBootInfo, UefiBootInfo};
+use std::fs::File;
+use std::path::PathBuf;
+
+let mut builder = IsoBuilder::new();
+builder.set_isohybrid(true);
+
+builder.add_file("kernel", PathBuf::from("my_kernel"))?;
+builder.add_file("initrd.img", PathBuf::from("my_initrd"))?;
+
+let boot_info = BootInfo {
+    bios_boot: Some(BiosBootInfo {
+        boot_catalog: PathBuf::from("BOOT.CAT"),
+        boot_image: PathBuf::from("isolinux.bin"),
+        destination_in_iso: "isolinux/isolinux.bin".to_string(),
+    }),
+    uefi_boot: Some(UefiBootInfo {
+        boot_image: PathBuf::from("BOOTX64.EFI"),
+        kernel_image: PathBuf::from("kernel"),
+        destination_in_iso: "EFI/BOOT/BOOTX64.EFI".to_string(),
+    }),
+};
+
+builder.set_boot_info(boot_info);
+
+let mut iso_file = File::create("output.iso")?;
+builder.build(&mut iso_file, Path::new("output.iso"), None, None)?;
+```
+
+## Project Structure
+
+- `src/lib.rs` - Main library exports and definitions
+- `src/iso/` - ISO 9660 filesystem implementation
+  - `builder.rs` - Core ISO building logic
+  - `iso_writer.rs` - File writing and descriptor creation
+  - `fs_node.rs` - Filesystem node representations
+  - `volume_descriptor.rs` - Volume descriptor structures
+  - `gpt/` - GUID Partition Table support for hybrid images
+- `src/fat.rs` - FAT32 ESP creation utilities
+- `src/utils.rs` - Utility functions and constants
+
+## Dependencies
+
+- `crc32fast` - CRC32 checksum calculation
+- `fatfs` - FAT filesystem manipulation
+- `uuid` - UUID generation for GPT partitions
+- `tempfile` - Temporary file handling
+- `regex` - Text processing utilities
+
+## License
+
+Licensed under both MIT and Apache 2.0 licenses.
+
+## Contributing
+
+Contributions are welcome! Please see the contributing guide at `docs/CONTRIBUTING.md`.


### PR DESCRIPTION
### docs(API): expand detailed API documentation with builder structures constants, and usage examples

Elaborate the API.md for `isobemak` crate by adding comprehensive descriptions of main functions like `build_iso`, configuration structures (e.g., IsoImage, BootInfo), the new IsoBuilder API, related structs like IsoFile and IsoDirectory, constants such as ESP_START_LBA, and multiple code examples for UEFI and BIOS bootable ISO creation. This enhances user guidance by detailing parameters, returns, hybrid iso support, and internal processes, replacing the previous minimal outline.

## Change details

- [ ] New feature
- [ ] Refactoring
- [ ] Bug fix
- [ ] CI / Build settings correction
- [x] Documentation update
---