### PR TITLE
refactor(iso): simplify boot entry creation logic

### DIFF
--- a/src/iso/builder.rs
+++ b/src/iso/builder.rs
@@ -105,30 +105,24 @@ impl IsoBuilder {
         esp_lba: Option<u32>,
         esp_size_sectors: Option<u32>,
     ) -> io::Result<Vec<BootCatalogEntry>> {
-        let mut boot_entries = Vec::new();
+        let mut entries = Vec::new();
+        let bi = self.boot_info.as_ref();
 
-        // Add BIOS boot entry
-        if let Some(bios_boot) = self.boot_info.as_ref().and_then(|bi| bi.bios_boot.as_ref()) {
-            boot_entries.push(create_bios_boot_entry(
-                &self.root,
-                &bios_boot.destination_in_iso,
-            )?);
-        }
-
-        // Add UEFI boot entry (conditional on isohybrid)
+        // UEFI boot entry
         if self.is_isohybrid {
-            if let (Some(esp_lba), Some(esp_size_sectors)) = (esp_lba, esp_size_sectors) {
-                boot_entries.push(create_uefi_esp_boot_entry(esp_lba, esp_size_sectors)?);
+            if let (Some(lba), Some(size)) = (esp_lba, esp_size_sectors) {
+                entries.push(create_uefi_esp_boot_entry(lba, size)?);
             }
-        } else if let Some(uefi_boot) = self.boot_info.as_ref().and_then(|bi| bi.uefi_boot.as_ref())
-        {
-            boot_entries.push(create_uefi_boot_entry(
-                &self.root,
-                &uefi_boot.destination_in_iso,
-            )?);
+        } else if let Some(u) = bi.and_then(|b| b.uefi_boot.as_ref()) {
+            entries.push(create_uefi_boot_entry(&self.root, &u.destination_in_iso)?);
         }
 
-        Ok(boot_entries)
+        // BIOS boot entry
+        if let Some(b) = bi.and_then(|b| b.bios_boot.as_ref()) {
+            entries.push(create_bios_boot_entry(&self.root, &b.destination_in_iso)?);
+        }
+
+        Ok(entries)
     }
 
     /// Writes MBR and GPT structures for hybrid ISOs.

--- a/tests/integration_tests/integrity_and_boot.rs
+++ b/tests/integration_tests/integrity_and_boot.rs
@@ -76,7 +76,7 @@ fn test_iso_integrity_and_boot_modes() -> io::Result<()> {
     let isoinfo_d_output = run_command("isoinfo", &["-d", "-i", iso_path.to_str().unwrap()])?;
     println!("isoinfo -d output (integrity test):\n{}", isoinfo_d_output);
     assert!(isoinfo_d_output.contains("El Torito VD version 1 found")); // Updated assertion
-    assert!(isoinfo_d_output.contains("Arch 0 (x86)")); // Updated assertion
+    assert!(isoinfo_d_output.contains("Arch 239")); // Updated assertion for UEFI priority
     assert!(isoinfo_d_output.contains("Boot media 0 (No Emulation Boot)")); // Updated assertion
     // Removed assertion for "EFI boot entry is present" as isoinfo -d does not output this string directly.
     // Detailed UEFI boot entry verification is handled in `test_create_isohybrid_uefi_iso`.


### PR DESCRIPTION
# Pull Request

## Overview

<!-- Describe the issue that this PR solves and its purpose. -->
- Related Issue: #39 
- Response details: Clean up the boot entry generation process in the ISO builder by simplifying access to boot information and improving variable naming. This change reorders the creation of UEFI and BIOS boot entries and reduces boilerplate code.


## Change details

- [ ] New feature
- [ ] Refactoring
- [x] Bug fix
- [ ] CI / Build settings correction
- [ ] Documentation update

## Build / Test Results

```sh
$ cargo check     # ✅
$ cargo test      # ✅
```
---