### PR TITLE
fix: correct sector unit conversion for isohybrid GPT structures

### DIFF
--- a/src/iso/builder.rs
+++ b/src/iso/builder.rs
@@ -147,7 +147,7 @@ impl IsoBuilder {
 
         // Write MBR (MBR uses 512-byte sector LBA values)
         iso_file.seek(SeekFrom::Start(0))?;
-        let mbr = create_mbr_for_gpt_hybrid(total_512_sectors as u32, self.is_isohybrid)?;
+        let mbr = create_mbr_for_gpt_hybrid(total_512_sectors.min(u32::MAX as u64) as u32, self.is_isohybrid)?;
         mbr.write_to(iso_file)?;
 
         // Write GPT structures if esp_size_sectors > 0

--- a/src/iso/builder.rs
+++ b/src/iso/builder.rs
@@ -132,40 +132,44 @@ impl IsoBuilder {
         total_lbas: u64,
         esp_size_sectors: Option<u32>,
     ) -> io::Result<()> {
-        // GPT structures require at least 69 LBAs
-        if total_lbas < 69 {
+        // GPT structures require at least 69 LBAs (in 512-byte units)
+        // total_lbas here is in 2048-byte ISO sectors, convert to 512-byte sectors
+        let total_512_sectors = total_lbas * 4;
+        if total_512_sectors < 69 {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
                 format!(
                     "ISO image is too small for isohybrid with GPT ({} sectors, requires at least 69)",
-                    total_lbas
+                    total_512_sectors
                 ),
             ));
         }
 
-        // Write MBR
+        // Write MBR (MBR uses 512-byte sector LBA values)
         iso_file.seek(SeekFrom::Start(0))?;
-        let mbr = create_mbr_for_gpt_hybrid(self.total_sectors, self.is_isohybrid)?;
+        let mbr = create_mbr_for_gpt_hybrid(total_512_sectors as u32, self.is_isohybrid)?;
         mbr.write_to(iso_file)?;
 
         // Write GPT structures if esp_size_sectors > 0
         if let Some(esp_size_sectors_val) = esp_size_sectors
             && esp_size_sectors_val > 0
         {
-            let esp_partition_start_lba = ESP_START_LBA;
-            let esp_partition_end_lba = esp_partition_start_lba + esp_size_sectors_val - 1;
+            // Convert ESP position and size from 2048-byte to 512-byte sector units
+            let esp_start_512 = (ESP_START_LBA as u64) * 4;
+            let esp_size_512 = (esp_size_sectors_val as u64) * 4;
+            let esp_partition_end_lba = esp_start_512 + esp_size_512 - 1;
 
             let esp_guid_str = EFI_SYSTEM_PARTITION_GUID;
             let esp_unique_guid_str = Uuid::new_v4().to_string();
             let partitions = vec![GptPartitionEntry::new(
                 esp_guid_str,
                 &esp_unique_guid_str,
-                esp_partition_start_lba as u64,
-                esp_partition_end_lba as u64,
+                esp_start_512,
+                esp_partition_end_lba,
                 "EFI System Partition",
                 0x0000000000000002, // EFI_PART_SYSTEM_PARTITION_ATTR_PLATFORM_REQUIRED
             )];
-            write_gpt_structures(iso_file, total_lbas, &partitions)?;
+            write_gpt_structures(iso_file, total_512_sectors, &partitions)?;
             iso_file.sync_data()?;
         }
 

--- a/src/iso/builder_utils.rs
+++ b/src/iso/builder_utils.rs
@@ -235,6 +235,8 @@ pub fn create_uefi_boot_entry(
 }
 
 /// Create a boot catalog entry for UEFI ESP partition
+/// `esp_lba` is in 2048-byte ISO sector units (the ISO filesystem LBA).
+/// El Torito boot catalog uses 512-byte sectors, so we multiply by 4.
 pub fn create_uefi_esp_boot_entry(
     esp_lba: u32,
     esp_size_sectors: u32,
@@ -243,7 +245,7 @@ pub fn create_uefi_esp_boot_entry(
         BootType::UefiEsp,
         &IsoDirectory::new(),
         None,
-        Some(esp_lba),
+        Some(esp_lba * 4), // Convert 2048-byte ISO sectors to 512-byte El Torito sectors
         Some(esp_size_sectors),
     )
 }

--- a/src/iso/builder_utils.rs
+++ b/src/iso/builder_utils.rs
@@ -245,7 +245,7 @@ pub fn create_uefi_esp_boot_entry(
         BootType::UefiEsp,
         &IsoDirectory::new(),
         None,
-        Some(esp_lba * 4), // Convert 2048-byte ISO sectors to 512-byte El Torito sectors
+        Some(esp_lba.saturating_mul(4)), // Convert 2048-byte ISO sectors to 512-byte El Torito sectors
         Some(esp_size_sectors),
     )
 }

--- a/src/iso/gpt/header.rs
+++ b/src/iso/gpt/header.rs
@@ -2,8 +2,6 @@ use std::io::{self, Seek, Write};
 use std::mem;
 use uuid::Uuid;
 
-use crate::iso::constants::ESP_START_LBA;
-
 // GPT Header structure
 #[repr(C, packed)]
 #[derive(Debug, Clone, Copy)]
@@ -35,6 +33,17 @@ impl GptHeader {
         let disk_guid_uuid = Uuid::new_v4();
         let disk_guid_bytes = disk_guid_uuid.into_bytes();
 
+        // For isohybrid ISO images:
+        // - MBR, GPT header, partition array are at LBA 0, 1, 2 (512-byte sectors)
+        // - GPT partition array is 128 entries * 128 bytes = 32 sectors (LBA 2..34)
+        // - First usable LBA is thus LBA 34 in 512-byte sectors
+        // - The ESP FAT image starts at LBA 34 * 4 = 136 in 512-byte sectors
+        //   (because ESP is placed at 2048-byte sector 34 = byte 69632)
+        // - But GPT doesn't know about the ISO sector layout; it only sees 512-byte sectors
+        //   So we reserve space for the partition array + header + MBR = 34 sectors
+        let first_usable_lba = 34u64; // MBR (1) + GPT Header (1) + Partition Array (32)
+        let last_usable_lba = total_lbas.saturating_sub(33); // Reserve 33 sectors for backup GPT at end
+
         GptHeader {
             signature: *b"EFI PART",
             revision: 0x00010000, // Version 1.0
@@ -43,8 +52,8 @@ impl GptHeader {
             _reserved0: 0,
             current_lba: 1, // LBA
             backup_lba: total_lbas - 1,
-            first_usable_lba: ESP_START_LBA as u64, // MBR (1) + GPT Header (1) + Partition Array (32)
-            last_usable_lba: total_lbas.saturating_sub(ESP_START_LBA as u64), // Last usable LBA before the backup GPT structures (33 sectors)
+            first_usable_lba,
+            last_usable_lba,
             disk_guid: disk_guid_bytes,
             partition_entry_lba,
             num_partition_entries,

--- a/src/iso/gpt/header.rs
+++ b/src/iso/gpt/header.rs
@@ -42,7 +42,7 @@ impl GptHeader {
         // - But GPT doesn't know about the ISO sector layout; it only sees 512-byte sectors
         //   So we reserve space for the partition array + header + MBR = 34 sectors
         let first_usable_lba = 34u64; // MBR (1) + GPT Header (1) + Partition Array (32)
-        let last_usable_lba = total_lbas.saturating_sub(33); // Reserve 33 sectors for backup GPT at end
+        let last_usable_lba = total_lbas.saturating_sub(34); // Reserve 33 sectors for backup GPT at end + 1 for alignment
 
         GptHeader {
             signature: *b"EFI PART",

--- a/tests/integration_tests/isohybrid_uefi.rs
+++ b/tests/integration_tests/isohybrid_uefi.rs
@@ -101,10 +101,12 @@ fn test_create_isohybrid_uefi_iso() -> io::Result<()> {
         isobemak::iso::boot_catalog::BOOT_CATALOG_BOOT_ENTRY_HEADER_ID,
         "UEFI boot entry is not marked bootable"
     );
+    // El Torito boot catalog uses 512-byte sector LBA values.
+    // ESP_START_LBA is in 2048-byte ISO sectors, so multiply by 4 for the boot catalog.
     assert_eq!(
         uefi_boot_lba,
-        isobemak::ESP_START_LBA,
-        "UEFI boot LBA in boot catalog is incorrect"
+        isobemak::ESP_START_LBA * 4,
+        "UEFI boot LBA in boot catalog is incorrect (should be 512-byte sector LBA)"
     );
 
     // The expected number of sectors in the boot catalog is the logical FAT size in 512-byte sectors,
@@ -116,8 +118,10 @@ fn test_create_isohybrid_uefi_iso() -> io::Result<()> {
         "UEFI boot sectors in boot catalog is incorrect"
     );
     println!(
-        "Verified UEFI boot entry: LBA={}, Sectors={} (expected: {})",
-        uefi_boot_lba, uefi_boot_sectors, expected_esp_sectors
+        "Verified UEFI boot entry: LBA={} (expected: {}), Sectors={} (expected: {})",
+        uefi_boot_lba,
+        isobemak::ESP_START_LBA * 4,
+        uefi_boot_sectors, expected_esp_sectors
     );
 
     // Verify ISO content using isoinfo -l


### PR DESCRIPTION
# Pull Request

## Overview

## Correction details

The root cause of the problem was that while MBR/GPT and the El Torito boot catalog used LBA in 512-byte sectors, the code internally used LBA in 2048-byte sectors (ISO sectors). This results in:

- UEFI firmware reads GPT and interprets the starting position of ESP as `LBA 34 × 512 = 17408th byte`
- Actual FAT data is placed at `LBA 34 × 2048 = 69632nd byte`

→ **The actual device tried to read the 17408th byte as FAT and got "NO bootfile found for UEFI!"**

QEMU/OVMF passed because El Torito's implementation of OVMF was more forgiving and read the ESP directly using the LBA from the El Torito boot catalog.

### Modified files

1. **`src/iso/builder.rs`**: Convert all LBA values to be passed to GPT/MBR with `write_hybrid_structures()` from 2048 to 512 byte sectors (x4)
2. **`src/iso/builder_utils.rs`**: Convert LBA of El Torito boot catalog entry from 2048 to 512 byte sector
3. **`src/iso/gpt/header.rs`**: Modify `first_usable_lba` in the GPT header to a fixed value of 34 (512 byte sector) and `last_usable_lba` to a value that takes into account the backup GPT portion.
4. **`tests/integration_tests/isohybrid_uefi.rs`**: Updated test expectation to `ESP_START_LBA * 4 = 136` (512 byte sector)

<!-- Describe the issue that this PR solves and its purpose. -->
- Related Issue: #43 

## Change details
- [x] Bug fix

## Build / Test Results

```sh
$ cargo check     # ✅
$ cargo test      # ✅
```

---