### PR TITLE
fix: correct El Torito boot catalog LBA sector size for CD-ROM media

### DIFF
--- a/src/iso/builder_utils.rs
+++ b/src/iso/builder_utils.rs
@@ -236,7 +236,9 @@ pub fn create_uefi_boot_entry(
 
 /// Create a boot catalog entry for UEFI ESP partition
 /// `esp_lba` is in 2048-byte ISO sector units (the ISO filesystem LBA).
-/// El Torito boot catalog uses 512-byte sectors, so we multiply by 4.
+/// For El Torito on CD-ROM media, the boot catalog LBA is in 2048-byte sectors,
+/// which matches ISO sector layout. GPT partition table separately records the
+/// ESP in 512-byte sector units for real hardware (USB, HDD) access.
 pub fn create_uefi_esp_boot_entry(
     esp_lba: u32,
     esp_size_sectors: u32,
@@ -245,7 +247,7 @@ pub fn create_uefi_esp_boot_entry(
         BootType::UefiEsp,
         &IsoDirectory::new(),
         None,
-        Some(esp_lba.saturating_mul(4)), // Convert 2048-byte ISO sectors to 512-byte El Torito sectors
+        Some(esp_lba), // Keep in 2048-byte ISO sectors for El Torito (CD-ROM media)
         Some(esp_size_sectors),
     )
 }

--- a/tests/integration_tests/isohybrid_uefi.rs
+++ b/tests/integration_tests/isohybrid_uefi.rs
@@ -101,12 +101,11 @@ fn test_create_isohybrid_uefi_iso() -> io::Result<()> {
         isobemak::iso::boot_catalog::BOOT_CATALOG_BOOT_ENTRY_HEADER_ID,
         "UEFI boot entry is not marked bootable"
     );
-    // El Torito boot catalog uses 512-byte sector LBA values.
-    // ESP_START_LBA is in 2048-byte ISO sectors, so multiply by 4 for the boot catalog.
+    // El Torito boot catalog on CD-ROM media uses 2048-byte ISO sector LBA values.
     assert_eq!(
         uefi_boot_lba,
-        isobemak::ESP_START_LBA * 4,
-        "UEFI boot LBA in boot catalog is incorrect (should be 512-byte sector LBA)"
+        isobemak::ESP_START_LBA,
+        "UEFI boot LBA in boot catalog is incorrect"
     );
 
     // The expected number of sectors in the boot catalog is the logical FAT size in 512-byte sectors,


### PR DESCRIPTION
The code previously multiplied the ESP LBA by 4 to convert from 2048-byte ISO sectors to 512-byte El Torito sectors. However, the El Torito specification on CD-ROM media uses 2048-byte sectors, matching the ISO filesystem LBA. This caused incorrect boot catalog entries.

Update `create_uefi_esp_boot_entry` to pass the ESP LBA directly (without conversion), fix related comments, and adjust the integration test assertion accordingly.

# Pull Request

## Overview
## Correction Details

The problem caused by the reviewer change was that **the LBA in the El Torito boot catalog was also converted to 512-byte sector units**.

- QEMU/OVMF recognizes the ISO image as a CD-ROM (2048 bytes/sector) → interprets the boot catalog's LBA as 2048-byte sectors.
- Reads LBA 136 (= 136 × 2048 = 278528th byte) → This is the ISO data area → Not an ESP → Boot failure, returns to shell.

### Corrected File

**`src/iso/builder_utils.rs`**: `create_uefi_esp_boot_entry()` changed `esp_lba * 4` back to the original `esp_lba` (2048-byte sector units).

**`tests/integration_tests/isohybrid_uefi.rs`**: The test expectation has also been reverted to the original `ESP_START_LBA` (34).

### Current Design (Correct State)

| Layer | LBA Unit | ESP Start Position |
|---------|---------|------------|
| El Torito Boot Catalog | 2048-byte sector | LBA 34 |
| Actual Data Placement (File Offset) | 2048-byte sector | LBA 34 (= 69632nd byte) |
| GPT Partition Table | 512-byte sector | LBA 136 (= 136 × 512 = 69632nd byte) |

This ensures that the ESP is found correctly in both QEMU (via El Torito) and on the actual machine (via GPT).

## Change details

- [x] Bug fix

## Build / Test Results

```sh
$ cargo check     # ✅
$ cargo test      # ✅
```

---