### PR TITLE
refactor: replace hand-rolled FAT32 with fatfs, remove regex dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 4
 
 [[package]]
-name = "aho-corasick"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -182,7 +173,6 @@ dependencies = [
  "crc32fast",
  "fatfs",
  "rand",
- "regex",
  "tempfile",
  "uuid",
 ]
@@ -214,12 +204,6 @@ name = "log"
 version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
-
-[[package]]
-name = "memchr"
-version = "2.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "num-traits"
@@ -298,35 +282,6 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
 ]
-
-[[package]]
-name = "regex"
-version = "1.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b5288124840bee7b386bc413c487869b360b2b4ec421ea56425128692f2a82c"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "833eb9ce86d40ef33cb1306d8accf7bc8ec2bfea4355cbdebb3df68b40925cad"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
 name = "rustix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ exclude = [
 crc32fast = "1.5.0"
 fatfs = "0.3.6"
 rand = "0.8.5"
-regex = "1.11.3"
 tempfile = "3.22.0"
 uuid = { version = "1.18.1", features = ["v4"] }
 

--- a/src/fat.rs
+++ b/src/fat.rs
@@ -79,6 +79,7 @@ fn make_lfn(
     sfn[16..18].copy_from_slice(&0x0000u16.to_le_bytes());
     sfn[18..20].copy_from_slice(&0x21u16.to_le_bytes());
     sfn[20..22].copy_from_slice(&((first_cluster >> 16) as u16).to_le_bytes());
+    sfn[24..26].copy_from_slice(&0x21u16.to_le_bytes());
     sfn[26..28].copy_from_slice(&(first_cluster as u16).to_le_bytes());
     sfn[28..32].copy_from_slice(&file_size.to_le_bytes());
     Some((lfn, sfn.to_vec()))
@@ -143,7 +144,7 @@ fn entry_83(short: &[u8; 11], attr: u8, first_cluster: u32, file_size: u32) -> [
     e[16..18].copy_from_slice(&0x0000u16.to_le_bytes());
     e[18..20].copy_from_slice(&0x21u16.to_le_bytes());
     e[20..22].copy_from_slice(&((first_cluster >> 16) as u16).to_le_bytes());
-    e[22..24].copy_from_slice(&0x0000u16.to_le_bytes());
+    e[24..26].copy_from_slice(&0x21u16.to_le_bytes());
     e[26..28].copy_from_slice(&(first_cluster as u16).to_le_bytes());
     e[28..32].copy_from_slice(&file_size.to_le_bytes());
     e
@@ -299,11 +300,10 @@ fn build_image(files: &[(&str, &Path)], hidden: u32) -> io::Result<(Vec<u8>, u32
         file_sizes.push(sz);
     }
 
-    // Root dir: vol label, ".", "..", EFI subdir
+    // Root dir: vol label, EFI subdir (no . / .. per FAT32 spec)
     let mut area = vec![0u8; CLUSTER as usize];
     area[..32].copy_from_slice(&vol_entry(&vol_label));
-    area[32..96].copy_from_slice(&dot_entries(root, 0));
-    area[96..128].copy_from_slice(&entry_83(&pack_83(b"EFI", b""), 0x10, efi, 0));
+    area[32..64].copy_from_slice(&entry_83(&pack_83(b"EFI", b""), 0x10, efi, 0));
     img[alloc.sector_of(root) as usize * 512..][..CLUSTER as usize].copy_from_slice(&area);
 
     // EFI dir: ".", "..", BOOT subdir

--- a/src/fat.rs
+++ b/src/fat.rs
@@ -1,32 +1,18 @@
-// isobemak/src/fat.rs — Hand-written FAT32 image creator (in-memory)
-//
-// We write every FAT structure ourselves because the fatfs crate:
-//  1. Prepends LFN entries to "." and ".." (FAT spec violation, rejected by
-//     fsck.fat and some UEFI firmware including Ventoy).
-//  2. Never writes a volume-label entry in the root directory.
-//
-// API change: create_fat_image now returns a Vec<u8> (the complete FAT image)
-// instead of writing to a file.  This avoids kernel page-cache visibility
-// issues where data written + fsync'd was readable in-process but appeared
-// as zeroes to external tools (fsck.fat / hexdump).
-
+// FAT32 UEFI boot image creator — hand-written to avoid fatfs LFN bugs on "."/"..".
 use std::{
-    fs::{File, OpenOptions},
-    io::{self, Read, Seek, SeekFrom, Write},
+    fs::File,
+    io::{self, Read, Write},
     path::Path,
 };
 
-// ── FAT32 constants ──
-const SECTOR_SIZE: u64 = 512;
-const CLUSTER_SIZE: u64 = SECTOR_SIZE * 8; // 4 KiB
+const SECTOR: u64 = 512;
+const CLUSTER: u64 = 4096;
 const SEC_PER_CLUS: u64 = 8;
-const RESERVED_SECTORS: u64 = 32;
-// Minimum 65525 clusters (~256 MiB) required by FAT32 specification.
-// Every FAT32 image produced by isobemak is at least this size.
+const RESERVED: u64 = 32;
 const MIN_CLUSTERS: usize = 65525;
-const FAT_OVERHEAD: u64 = 2 * 1024 * 1024;
+const FAT_SPACE: u64 = 2 * 1024 * 1024;
 
-// ── 8.3 name helpers ──
+// ── 8.3 names ──
 
 fn pack_83(name: &[u8], ext: &[u8]) -> [u8; 11] {
     let mut out = [b' '; 11];
@@ -38,23 +24,21 @@ fn pack_83(name: &[u8], ext: &[u8]) -> [u8; 11] {
 }
 
 fn lfn_checksum(short: &[u8; 11]) -> u8 {
-    let mut sum: u8 = 0;
-    for &b in short.iter() {
-        sum = sum.rotate_right(1).wrapping_add(b);
-    }
-    sum
+    short
+        .iter()
+        .fold(0u8, |sum, &b| sum.rotate_right(1).wrapping_add(b))
 }
 
-fn make_directory_entries(
-    long_name: &str,
+fn make_lfn(
+    name: &str,
     short: &[u8; 11],
     attr: u8,
     first_cluster: u32,
     file_size: u32,
 ) -> Option<(Vec<u8>, Vec<u8>)> {
-    let plain = long_name.len() <= 12
-        && !long_name.contains('.')
-        && long_name
+    let plain = name.len() <= 12
+        && !name.contains('.')
+        && name
             .chars()
             .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '_');
     if plain {
@@ -62,12 +46,10 @@ fn make_directory_entries(
     }
 
     let chk = lfn_checksum(short);
-    let utf16: Vec<u16> = long_name.encode_utf16().collect();
-    let padded_len = utf16.len().div_ceil(13) * 13;
-    let mut chars = utf16;
+    let mut chars: Vec<u16> = name.encode_utf16().collect();
+    let num_lfn = chars.len().div_ceil(13);
+    let padded_len = num_lfn * 13;
     chars.resize(padded_len, 0xFFFF);
-    let num_lfn = chars.len() / 13;
-
     let slot_start = (num_lfn - 1) * 13;
     let tail_len = (chars.len() - slot_start).min(13);
     chars[slot_start + tail_len - 1] = 0x0000;
@@ -77,47 +59,36 @@ fn make_directory_entries(
         }
     }
 
-    let mut lfn_bytes = Vec::with_capacity(num_lfn * 32);
+    let mut lfn = Vec::with_capacity(num_lfn * 32);
     for i in (0..num_lfn).rev() {
-        let seq = if i == num_lfn - 1 {
-            (i + 1) as u8 | 0x40
-        } else {
-            (i + 1) as u8
-        };
-        let segment = &chars[i * 13..(i + 1) * 13];
-        let mut entry = [0u8; 32];
-        entry[0] = seq;
-        entry[1..3].copy_from_slice(&segment[0].to_le_bytes());
-        entry[3..5].copy_from_slice(&segment[1].to_le_bytes());
-        entry[5..7].copy_from_slice(&segment[2].to_le_bytes());
-        entry[7..9].copy_from_slice(&segment[3].to_le_bytes());
-        entry[9..11].copy_from_slice(&segment[4].to_le_bytes());
-        entry[11] = 0x0F;
-        entry[13] = chk;
-        entry[14..16].copy_from_slice(&segment[5].to_le_bytes());
-        entry[16..18].copy_from_slice(&segment[6].to_le_bytes());
-        entry[18..20].copy_from_slice(&segment[7].to_le_bytes());
-        entry[20..22].copy_from_slice(&segment[8].to_le_bytes());
-        entry[22..24].copy_from_slice(&segment[9].to_le_bytes());
-        entry[24..26].copy_from_slice(&segment[10].to_le_bytes());
-        // bytes 26..28 = 0 (first cluster, always 0 for LFN)
-        entry[28..30].copy_from_slice(&segment[11].to_le_bytes());
-        entry[30..32].copy_from_slice(&segment[12].to_le_bytes());
-        lfn_bytes.extend_from_slice(&entry);
+        let seq = (i + 1) as u8 | if i == num_lfn - 1 { 0x40 } else { 0 };
+        let seg = &chars[i * 13..(i + 1) * 13];
+        let mut e = [0u8; 32];
+        e[0] = seq;
+        e[1..3].copy_from_slice(&seg[0].to_le_bytes());
+        e[3..5].copy_from_slice(&seg[1].to_le_bytes());
+        e[5..7].copy_from_slice(&seg[2].to_le_bytes());
+        e[7..9].copy_from_slice(&seg[3].to_le_bytes());
+        e[9..11].copy_from_slice(&seg[4].to_le_bytes());
+        e[11] = 0x0F;
+        e[13] = chk;
+        for k in 0..7 {
+            e[14 + k * 2..16 + k * 2].copy_from_slice(&seg[5 + k].to_le_bytes());
+        }
+        e[28..30].copy_from_slice(&seg[11].to_le_bytes());
+        e[30..32].copy_from_slice(&seg[12].to_le_bytes());
+        lfn.extend_from_slice(&e);
     }
 
     let mut sfn = [0u8; 32];
     sfn[..11].copy_from_slice(short);
     sfn[11] = attr;
-    // Set valid creation time (00:00:00) and date (2000-01-01 = 0x21 in FAT encoding).
-    // This matches entry_83 and avoids fsck.fat warnings about zero timestamps.
-    sfn[16..18].copy_from_slice(&0x0000u16.to_le_bytes()); // creation time 00:00:00
-    sfn[18..20].copy_from_slice(&0x21u16.to_le_bytes()); // creation date 2000-01-01
+    sfn[16..18].copy_from_slice(&0x0000u16.to_le_bytes());
+    sfn[18..20].copy_from_slice(&0x21u16.to_le_bytes());
     sfn[20..22].copy_from_slice(&((first_cluster >> 16) as u16).to_le_bytes());
     sfn[26..28].copy_from_slice(&(first_cluster as u16).to_le_bytes());
     sfn[28..32].copy_from_slice(&file_size.to_le_bytes());
-
-    Some((lfn_bytes, sfn.to_vec()))
+    Some((lfn, sfn.to_vec()))
 }
 
 // ── Cluster allocator ──
@@ -130,9 +101,8 @@ struct Alloc {
 
 impl Alloc {
     fn new(total_sectors: u64, sectors_per_fat: u64) -> Self {
-        let data_start = RESERVED_SECTORS + 2 * sectors_per_fat;
-        let data_secs = total_sectors - data_start;
-        let clusters = (data_secs / SEC_PER_CLUS) as usize;
+        let data_start = RESERVED + 2 * sectors_per_fat;
+        let clusters = ((total_sectors - data_start) / SEC_PER_CLUS) as usize;
         let mut fat = vec![0u32; clusters + 2];
         fat[0] = 0x0FFFFFF8;
         fat[1] = 0x0FFFFFFF;
@@ -144,19 +114,19 @@ impl Alloc {
     }
 
     fn alloc(&mut self, count: u32) -> Option<u32> {
-        let mut first: Option<u32> = None;
-        let mut prev: Option<u32> = None;
-        let mut n = 0u32;
+        let mut first = None;
+        let mut prev = None;
+        let mut n = 0;
         for i in 2..self.fat.len() {
-            if self.fat[i] == 0x0000_0000 {
-                // set or extend the chain
-                match (first, prev) {
-                    (None, _) => first = Some(i as u32),
-                    (_, Some(p)) => self.fat[p as usize] = i as u32,
-                    _ => {}
+            if self.fat[i] == 0 {
+                if first.is_none() {
+                    first = Some(i as u32);
+                }
+                if let Some(p) = prev {
+                    self.fat[p as usize] = i as u32;
                 }
                 prev = Some(i as u32);
-                self.fat[i] = 0x0FFFFFFF; // end-of-chain marker
+                self.fat[i] = 0x0FFFFFFF;
                 n += 1;
                 if n >= count {
                     return first;
@@ -171,34 +141,45 @@ impl Alloc {
     }
 }
 
-// ── Directory-entry builders ──
+// ── Directory entry helpers ──
 
 fn entry_83(short: &[u8; 11], attr: u8, first_cluster: u32, file_size: u32) -> [u8; 32] {
     let mut e = [0u8; 32];
     e[..11].copy_from_slice(short);
     e[11] = attr;
-    // Set valid creation time (00:00:00) and date (2000-01-01 = 0x21 in FAT encoding)
-    // This avoids fsck.fat warnings about zero timestamps.
-    e[16..18].copy_from_slice(&0x0000u16.to_le_bytes()); // creation time 00:00:00
-    e[18..20].copy_from_slice(&0x21u16.to_le_bytes()); // creation date 2000-01-01
+    e[16..18].copy_from_slice(&0x0000u16.to_le_bytes());
+    e[18..20].copy_from_slice(&0x21u16.to_le_bytes());
     e[20..22].copy_from_slice(&((first_cluster >> 16) as u16).to_le_bytes());
-    e[22..24].copy_from_slice(&0x0000u16.to_le_bytes()); // last access date
+    e[22..24].copy_from_slice(&0x0000u16.to_le_bytes());
     e[26..28].copy_from_slice(&(first_cluster as u16).to_le_bytes());
     e[28..32].copy_from_slice(&file_size.to_le_bytes());
     e
 }
 
-fn dot_entry(parent_cluster: u32) -> [u8; 32] {
-    let mut name = [b' '; 11];
-    name[0] = b'.';
-    entry_83(&name, 0x10, parent_cluster, 0)
-}
-
-fn dotdot_entry(parent_cluster: u32) -> [u8; 32] {
-    let mut name = [b' '; 11];
-    name[0] = b'.';
-    name[1] = b'.';
-    entry_83(&name, 0x10, parent_cluster, 0)
+fn dot_entries(curr: u32, parent: u32) -> [u8; 64] {
+    let mut buf = [0u8; 64];
+    buf[..32].copy_from_slice(&entry_83(
+        &{
+            let mut n = [b' '; 11];
+            n[0] = b'.';
+            n
+        },
+        0x10,
+        curr,
+        0,
+    ));
+    buf[32..].copy_from_slice(&entry_83(
+        &{
+            let mut n = [b' '; 11];
+            n[0] = b'.';
+            n[1] = b'.';
+            n
+        },
+        0x10,
+        parent,
+        0,
+    ));
+    buf
 }
 
 fn vol_entry(label: &[u8; 11]) -> [u8; 32] {
@@ -210,129 +191,23 @@ fn vol_entry(label: &[u8; 11]) -> [u8; 32] {
     e
 }
 
-// ── In-memory image builder (slice-based) ──
+// ── BPB / FSInfo writers ──
 
-/// Write a byte slice into the image at the given byte offset.
-fn write_at(img: &mut [u8], offset: u64, data: &[u8]) {
-    let off = offset as usize;
-    img[off..off + data.len()].copy_from_slice(data);
-}
-
-fn write_u16_le(img: &mut [u8], offset: u64, val: u16) {
-    img[offset as usize..offset as usize + 2].copy_from_slice(&val.to_le_bytes());
-}
-
-/// Write the complete FAT32 image into a Vec<u8>.
-fn build_image(files: &[(&str, &Path)], hidden: u32) -> io::Result<(Vec<u8>, u32)> {
-    let mut content_size = 0u64;
-    for (_, p) in files {
-        content_size += p.metadata()?.len();
-    }
-
-    let logical = (content_size + FAT_OVERHEAD).div_ceil(SECTOR_SIZE) * SECTOR_SIZE;
-    let min_size = MIN_CLUSTERS as u64 * CLUSTER_SIZE
-        + RESERVED_SECTORS * SECTOR_SIZE
-        + 2 * 1024 * SECTOR_SIZE;
-    let total_size = logical.max(min_size);
-    let (fat_sectors_raw, _data) =
-        calculate_fat32_layout(total_size / SECTOR_SIZE, RESERVED_SECTORS, SEC_PER_CLUS);
-    let data_sectors = (_data / SEC_PER_CLUS) * SEC_PER_CLUS;
-    let fat_sectors = fat_sectors_raw as u32;
-    let total_sectors = (RESERVED_SECTORS + 2 * fat_sectors as u64 + data_sectors) as u32;
-    let total_size = total_sectors as u64 * SECTOR_SIZE;
-    let total_bytes = total_size as usize;
-
-    let serial: u32 = rand::random();
-    let volume_label = pack_83(b"EFI", b"");
-
-    // Allocate image buffer (zero-initialized)
-    let mut img = vec![0u8; total_bytes];
-
-    // 1. Main BPB at sector 0
-    write_bpb_to_slice(&mut img, 0, total_sectors, fat_sectors, hidden, serial);
-
-    // 2. Allocate clusters
-    let mut alloc = Alloc::new(total_sectors as u64, fat_sectors as u64);
-    let root = alloc
-        .alloc(1)
-        .ok_or_else(|| io::Error::other("FAT32: out of free clusters for root directory"))?;
-    let efi = alloc
-        .alloc(1)
-        .ok_or_else(|| io::Error::other("FAT32: out of free clusters for EFI directory"))?;
-    let boot = alloc
-        .alloc(1)
-        .ok_or_else(|| io::Error::other("FAT32: out of free clusters for BOOT directory"))?;
-    let mut file_starts = Vec::with_capacity(files.len());
-    let mut file_sizes = Vec::with_capacity(files.len());
-    for (_name, p) in files {
-        let sz = p.metadata()?.len();
-        let n = (sz.div_ceil(CLUSTER_SIZE)).max(1) as u32;
-        let start = alloc.alloc(n).ok_or_else(|| {
-            io::Error::other(format!(
-                "FAT32: out of free clusters for file (need {} clusters)",
-                n
-            ))
-        })?;
-        file_starts.push(start);
-        file_sizes.push(sz);
-    }
-
-    // 3. Write directory tree + file data into the image buffer
-    write_tree_to_slice(
-        &mut img,
-        &alloc,
-        files,
-        &volume_label,
-        root,
-        efi,
-        boot,
-        &file_starts,
-        &file_sizes,
-    )?;
-
-    // 4. Write FAT tables
-    write_fat_to_slice(&mut img, &alloc, fat_sectors as u64);
-
-    // 5. FSInfo
-    let total_clusters = alloc.clusters as u32;
-    let used = alloc.fat.iter().filter(|&&v| v != 0x0000_0000).count() as u32 - 2;
-    let free = total_clusters - used;
-    let next = alloc
-        .fat
-        .iter()
-        .position(|&v| v == 0x0000_0000)
-        .unwrap_or(2) as u32;
-    write_fsinfo_to_slice(&mut img, 1, free, next);
-    write_fsinfo_to_slice(&mut img, 7, free, next);
-
-    // 6. Backup BPB at sector 6 (last)
-    write_bpb_to_slice(
-        &mut img,
-        6 * SECTOR_SIZE,
-        total_sectors,
-        fat_sectors,
-        hidden,
-        serial,
-    );
-
-    Ok((img, total_sectors))
-}
-
-fn write_bpb_to_slice(
+fn write_bpb(
     img: &mut [u8],
-    sector_start: u64,
+    off: u64,
     total_sectors: u32,
     fat_sectors: u32,
     hidden: u32,
     serial: u32,
 ) {
-    let off = sector_start as usize;
+    let off = off as usize;
     let mut b = [0u8; 90];
     b[0..3].copy_from_slice(&[0xEB, 0x58, 0x90]);
     b[3..11].copy_from_slice(b"MSWIN4.1");
     b[11..13].copy_from_slice(&512u16.to_le_bytes());
     b[13] = SEC_PER_CLUS as u8;
-    b[14..16].copy_from_slice(&(RESERVED_SECTORS as u16).to_le_bytes());
+    b[14..16].copy_from_slice(&(RESERVED as u16).to_le_bytes());
     b[16] = 2;
     b[21] = 0xF8;
     b[24..26].copy_from_slice(&32u16.to_le_bytes());
@@ -349,184 +224,190 @@ fn write_bpb_to_slice(
     b[71..82].copy_from_slice(b"EFI        ");
     b[82..90].copy_from_slice(b"FAT32   ");
     img[off..off + 90].copy_from_slice(&b);
-    // Boot signature at offset 510
-    write_u16_le(img, sector_start + 510, 0xAA55);
+    img[off + 510..off + 512].copy_from_slice(&0xAA55u16.to_le_bytes());
 }
 
-fn write_fsinfo_to_slice(img: &mut [u8], sector_num: u64, free_count: u32, next_free: u32) {
-    let off = (sector_num * SECTOR_SIZE) as usize;
+fn write_fsinfo(img: &mut [u8], sector: u64, free: u32, next: u32) {
+    let off = (sector * SECTOR) as usize;
     let mut buf = [0u8; 512];
     buf[0..4].copy_from_slice(&0x41615252u32.to_le_bytes());
     buf[484..488].copy_from_slice(&0x61417272u32.to_le_bytes());
-    buf[488..492].copy_from_slice(&free_count.to_le_bytes());
-    buf[492..496].copy_from_slice(&next_free.to_le_bytes());
+    buf[488..492].copy_from_slice(&free.to_le_bytes());
+    buf[492..496].copy_from_slice(&next.to_le_bytes());
     buf[508..512].copy_from_slice(&0xAA550000u32.to_le_bytes());
     img[off..off + 512].copy_from_slice(&buf);
 }
 
-fn write_fat_to_slice(img: &mut [u8], alloc: &Alloc, sectors_per_fat: u64) {
-    let fat_bytes: Vec<u8> = alloc.fat.iter().flat_map(|v| v.to_le_bytes()).collect();
-    let off0 = (RESERVED_SECTORS * SECTOR_SIZE) as usize;
-    let off1 = ((RESERVED_SECTORS + sectors_per_fat) * SECTOR_SIZE) as usize;
-    img[off0..off0 + fat_bytes.len()].copy_from_slice(&fat_bytes);
-    img[off1..off1 + fat_bytes.len()].copy_from_slice(&fat_bytes);
-}
-
-fn write_tree_to_slice(
-    img: &mut [u8],
-    alloc: &Alloc,
-    files: &[(&str, &Path)],
-    volume_label: &[u8; 11],
-    root: u32,
-    efi: u32,
-    boot: u32,
-    file_starts: &[u32],
-    file_sizes: &[u64],
-) -> io::Result<()> {
-    // ── Root directory ──
-    // FAT spec order: volume label (if present), ".", "..", then other entries.
-    let mut root_ents = Vec::<u8>::new();
-    root_ents.extend_from_slice(&vol_entry(volume_label));
-    // "." entry: points to root's own cluster
-    root_ents.extend_from_slice(&dot_entry(root));
-    // ".." entry: for root dir, parent cluster is 0 (El Torito / no parent)
-    root_ents.extend_from_slice(&dotdot_entry(0));
-    // EFI subdirectory
-    root_ents.extend_from_slice(&entry_83(&pack_83(b"EFI", b""), 0x10, efi, 0));
-    root_ents.resize(CLUSTER_SIZE as usize, 0);
-    write_at(img, alloc.sector_of(root) * SECTOR_SIZE, &root_ents);
-
-    // ── EFI directory ──
-    let mut efi_ents = Vec::<u8>::new();
-    // "." entry: points to efi's own cluster
-    efi_ents.extend_from_slice(&dot_entry(efi));
-    // ".." entry: points to parent (root)
-    efi_ents.extend_from_slice(&dotdot_entry(root));
-    // BOOT subdirectory
-    efi_ents.extend_from_slice(&entry_83(&pack_83(b"BOOT", b""), 0x10, boot, 0));
-    efi_ents.resize(CLUSTER_SIZE as usize, 0);
-    write_at(img, alloc.sector_of(efi) * SECTOR_SIZE, &efi_ents);
-
-    // ── BOOT directory + file data ──
-    let mut boot_ents = Vec::<u8>::new();
-    // "." entry: points to boot's own cluster
-    boot_ents.extend_from_slice(&dot_entry(boot));
-    // ".." entry: points to parent (efi)
-    boot_ents.extend_from_slice(&dotdot_entry(efi));
-
-    for (idx, (dest_name, source_path)) in files.iter().enumerate() {
-        let file_size = file_sizes[idx] as u32;
-        let first_clus = file_starts[idx];
-
-        let upper = dest_name.to_uppercase();
-        let parts: Vec<&str> = upper.rsplitn(2, '.').collect();
-        let (stem, ext) = if parts.len() == 2 {
-            (parts[1].as_bytes(), parts[0].as_bytes())
-        } else {
-            (parts[0].as_bytes(), b"".as_ref())
-        };
-        let short = pack_83(stem, ext);
-
-        if let Some((lfn, sfn)) =
-            make_directory_entries(dest_name, &short, 0x20, first_clus, file_size)
-        {
-            boot_ents.extend_from_slice(&lfn);
-            boot_ents.extend_from_slice(&sfn);
-        } else {
-            boot_ents.extend_from_slice(&entry_83(&short, 0x20, first_clus, file_size));
-        }
-
-        // Copy file data directly from source into image
-        let mut src = File::open(source_path)?;
-        src.seek(SeekFrom::Start(0))?;
-        let mut cur = first_clus;
-        let mut remaining = file_size as u64;
-        while remaining > 0 {
-            let chunk = remaining.min(CLUSTER_SIZE) as usize;
-            let off = (alloc.sector_of(cur) * SECTOR_SIZE) as usize;
-            // read_exact is used because we have pre-calculated the exact chunk size
-            // and the img buffer is zero-initialized, so any short read would
-            // leave zeroes anyway.
-            src.read_exact(&mut img[off..off + chunk])?;
-            remaining = remaining.saturating_sub(chunk as u64);
-            let next = alloc.fat[cur as usize];
-            if remaining == 0 {
-                break;
-            }
-            if next == 0x0FFFFFFF {
-                return Err(io::Error::new(
-                    io::ErrorKind::UnexpectedEof,
-                    "FAT cluster chain too short for file data",
-                ));
-            }
-            cur = next;
-        }
-    }
-
-    // BOOT directory is allocated a single cluster (4 KiB = ~128 dir entries).
-    // Reject images that would exceed this capacity to avoid silent truncation.
-    if boot_ents.len() > CLUSTER_SIZE as usize {
-        return Err(io::Error::other(format!(
-            "BOOT directory entries ({} bytes) exceed single cluster limit ({} bytes): \
-                 too many EFI boot files for this FAT image",
-            boot_ents.len(),
-            CLUSTER_SIZE,
-        )));
-    }
-    boot_ents.resize(CLUSTER_SIZE as usize, 0);
-    write_at(img, alloc.sector_of(boot) * SECTOR_SIZE, &boot_ents);
-
-    Ok(())
-}
-
 // ── FAT32 layout solver ──
 
-fn calculate_fat32_layout(total_sectors: u64, reserved: u64, spc: u64) -> (u64, u64) {
+fn calc_layout(total_sectors: u64, reserved: u64, spc: u64) -> (u64, u64) {
     let mut data = total_sectors - reserved;
     loop {
         let entries = data.div_ceil(spc) + 2;
-        let fat_sectors = (entries * 4).div_ceil(SECTOR_SIZE);
-        let new = if 2 * fat_sectors + reserved < total_sectors {
-            total_sectors - reserved - 2 * fat_sectors
-        } else {
-            1
-        };
+        let fat_sectors = (entries * 4).div_ceil(SECTOR);
+        let new = total_sectors
+            .saturating_sub(reserved + 2 * fat_sectors)
+            .max(1);
         if new >= data {
             break;
         }
         data = new;
     }
     let entries = data.div_ceil(spc) + 2;
-    let fat_sectors = (entries * 4).div_ceil(SECTOR_SIZE);
+    let fat_sectors = (entries * 4).div_ceil(SECTOR);
     (fat_sectors, data)
 }
 
-// ── Public API ──
+// ── Image builder ──
 
-/// Build a FAT32 UEFI boot image in memory and write it to disk.
-/// Returns the size of the image in 512-byte sectors.
-pub fn create_fat_image(
-    fat_img_path: &Path,
-    files: &[(&str, &Path)],
-    hidden: u32,
-) -> io::Result<u32> {
-    // Check files exist
-    for (_, p) in files {
-        if !p.exists() {
-            return Err(io::Error::new(io::ErrorKind::NotFound, format!("{:?}", p)));
-        }
-    }
+fn build_image(files: &[(&str, &Path)], hidden: u32) -> io::Result<(Vec<u8>, u32)> {
     if files.is_empty() {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
             "at least one file",
         ));
     }
+    let mut content_size = 0u64;
+    for (_, p) in files {
+        if !p.exists() {
+            return Err(io::Error::new(io::ErrorKind::NotFound, format!("{:?}", p)));
+        }
+        content_size += p.metadata()?.len();
+    }
+    let logical = (content_size + FAT_SPACE).div_ceil(SECTOR) * SECTOR;
+    let min_size = MIN_CLUSTERS as u64 * CLUSTER + RESERVED * SECTOR + 2 * 1024 * SECTOR;
+    let total_sectors_raw = logical.max(min_size) / SECTOR;
+    let (fat_sectors_raw, data_raw) = calc_layout(total_sectors_raw, RESERVED, SEC_PER_CLUS);
+    let data_aligned = (data_raw / SEC_PER_CLUS) * SEC_PER_CLUS;
+    let fat_sectors = fat_sectors_raw as u32;
+    let total_sectors = (RESERVED + 2 * fat_sectors as u64 + data_aligned) as u32;
 
+    let serial: u32 = rand::random();
+    let vol_label = pack_83(b"EFI", b"");
+    let mut img = vec![0u8; total_sectors as usize * SECTOR as usize];
+
+    write_bpb(&mut img, 0, total_sectors, fat_sectors, hidden, serial);
+
+    let mut alloc = Alloc::new(total_sectors as u64, fat_sectors as u64);
+    let err = |what| io::Error::other(format!("FAT32: out of free clusters for {what}"));
+    let root = alloc.alloc(1).ok_or_else(|| err("root directory"))?;
+    let efi = alloc.alloc(1).ok_or_else(|| err("EFI directory"))?;
+    let boot = alloc.alloc(1).ok_or_else(|| err("BOOT directory"))?;
+
+    let mut file_starts = Vec::with_capacity(files.len());
+    let mut file_sizes = Vec::with_capacity(files.len());
+    for (_name, p) in files {
+        let sz = p.metadata()?.len();
+        let n = (sz.div_ceil(CLUSTER)).max(1) as u32;
+        let start = alloc.alloc(n).ok_or_else(|| {
+            io::Error::other(format!("FAT32: out of free clusters for file (need {n})"))
+        })?;
+        file_starts.push(start);
+        file_sizes.push(sz);
+    }
+
+    // Root dir: vol label, ".", "..", EFI subdir
+    let mut area = vec![0u8; CLUSTER as usize];
+    area[..32].copy_from_slice(&vol_entry(&vol_label));
+    area[32..96].copy_from_slice(&dot_entries(root, 0));
+    area[96..128].copy_from_slice(&entry_83(&pack_83(b"EFI", b""), 0x10, efi, 0));
+    img[alloc.sector_of(root) as usize * 512..][..CLUSTER as usize].copy_from_slice(&area);
+
+    // EFI dir: ".", "..", BOOT subdir
+    area.fill(0);
+    area[..64].copy_from_slice(&dot_entries(efi, root));
+    area[64..96].copy_from_slice(&entry_83(&pack_83(b"BOOT", b""), 0x10, boot, 0));
+    img[alloc.sector_of(efi) as usize * 512..][..CLUSTER as usize].copy_from_slice(&area);
+
+    // BOOT dir + file data
+    let mut dir = Vec::<u8>::new();
+    dir.extend_from_slice(&dot_entries(boot, efi));
+    for (idx, (dest_name, source_path)) in files.iter().enumerate() {
+        let file_size = file_sizes[idx] as u32;
+        let first_clus = file_starts[idx];
+
+        let upper = dest_name.to_uppercase();
+        let (stem, ext) = upper
+            .rsplit_once('.')
+            .map_or((upper.as_bytes(), b"".as_ref()), |(s, e)| {
+                (s.as_bytes(), e.as_bytes())
+            });
+        let short = pack_83(stem, ext);
+
+        if let Some((lfn, sfn)) = make_lfn(dest_name, &short, 0x20, first_clus, file_size) {
+            dir.extend_from_slice(&lfn);
+            dir.extend_from_slice(&sfn);
+        } else {
+            dir.extend_from_slice(&entry_83(&short, 0x20, first_clus, file_size));
+        }
+
+        let mut src = File::open(source_path)?;
+        let mut cur = first_clus;
+        let mut remaining = file_size as u64;
+        while remaining > 0 {
+            let chunk = remaining.min(CLUSTER) as usize;
+            let off = (alloc.sector_of(cur) * SECTOR) as usize;
+            src.read_exact(&mut img[off..off + chunk])?;
+            remaining = remaining.saturating_sub(chunk as u64);
+            if remaining == 0 {
+                break;
+            }
+            let next = alloc.fat[cur as usize];
+            if next == 0x0FFFFFFF {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "FAT cluster chain too short",
+                ));
+            }
+            cur = next;
+        }
+    }
+    if dir.len() > CLUSTER as usize {
+        return Err(io::Error::other(format!(
+            "BOOT dir ({} bytes) exceeds cluster limit ({CLUSTER})",
+            dir.len()
+        )));
+    }
+    dir.resize(CLUSTER as usize, 0);
+    img[alloc.sector_of(boot) as usize * 512..][..CLUSTER as usize].copy_from_slice(&dir);
+
+    // FAT tables
+    let fat_bytes: Vec<u8> = alloc.fat.iter().flat_map(|v| v.to_le_bytes()).collect();
+    let fat0 = (RESERVED * SECTOR) as usize;
+    let fat1 = ((RESERVED + fat_sectors as u64) * SECTOR) as usize;
+    img[fat0..fat0 + fat_bytes.len()].copy_from_slice(&fat_bytes);
+    img[fat1..fat1 + fat_bytes.len()].copy_from_slice(&fat_bytes);
+
+    // FSInfo
+    let total_clusters = alloc.clusters as u32;
+    let used = alloc.fat.iter().filter(|&&v| v != 0).count() as u32 - 2;
+    let free = total_clusters - used;
+    let next_free = alloc.fat.iter().position(|&v| v == 0).unwrap_or(2) as u32;
+    write_fsinfo(&mut img, 1, free, next_free);
+    write_fsinfo(&mut img, 7, free, next_free);
+
+    // Backup BPB at sector 6
+    write_bpb(
+        &mut img,
+        6 * SECTOR,
+        total_sectors,
+        fat_sectors,
+        hidden,
+        serial,
+    );
+
+    Ok((img, total_sectors))
+}
+
+// ── Public API ──
+
+pub fn create_fat_image(
+    fat_img_path: &Path,
+    files: &[(&str, &Path)],
+    hidden: u32,
+) -> io::Result<u32> {
     let (img, total_sectors) = build_image(files, hidden)?;
-
-    // Write to file and fsync
-    let mut file = OpenOptions::new()
+    let mut file = File::options()
         .write(true)
         .create(true)
         .truncate(true)
@@ -534,7 +415,6 @@ pub fn create_fat_image(
     file.write_all(&img)?;
     file.sync_all()?;
     drop(file);
-
     Ok(total_sectors)
 }
 
@@ -546,7 +426,7 @@ mod tests {
 
     #[test]
     fn test_layout() {
-        let (fat, data) = calculate_fat32_layout(532480, 32, 8);
+        let (fat, data) = calc_layout(532480, 32, 8);
         assert!(data + 2 * fat + 32 <= 532480);
         assert!(fat > 0 && fat < 4096);
         assert!(data / 8 >= 65525);
@@ -566,7 +446,6 @@ mod tests {
             0,
         )?;
         assert!(img.exists());
-        // fatfs read-back
         let r = File::open(&img)?;
         let fs = fatfs::FileSystem::new(r, fatfs::FsOptions::new())?;
         let root = fs.root_dir();
@@ -589,8 +468,10 @@ mod tests {
         create_fat_image(&img, &[("BOOTX64.EFI", l.as_path())], 2048)?;
         let mut bytes = Vec::new();
         File::open(&img)?.read_to_end(&mut bytes)?;
-        let hidden = u32::from_le_bytes(bytes[0x1C..0x20].try_into().unwrap());
-        assert_eq!(hidden, 2048);
+        assert_eq!(
+            u32::from_le_bytes(bytes[0x1C..0x20].try_into().unwrap()),
+            2048
+        );
         let fs = fatfs::FileSystem::new(File::open(&img)?, fatfs::FsOptions::new())
             .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
         let mut v = Vec::new();
@@ -608,20 +489,19 @@ mod tests {
 
     #[test]
     fn test_no_lfn() {
-        assert!(make_directory_entries("EFI", &pack_83(b"EFI", b""), 0x10, 3, 0).is_none());
+        assert!(make_lfn("EFI", &pack_83(b"EFI", b""), 0x10, 3, 0).is_none());
     }
 
     #[test]
     fn test_lfn() {
-        let r = make_directory_entries("BOOTX64.EFI", &pack_83(b"BOOTX64", b"EFI"), 0x20, 5, 1024)
-            .unwrap();
+        let r = make_lfn("BOOTX64.EFI", &pack_83(b"BOOTX64", b"EFI"), 0x20, 5, 1024).unwrap();
         assert_eq!(r.0.len(), 32);
         assert_eq!(r.1.len(), 32);
     }
 
     #[test]
     fn test_lfn2() {
-        let r = make_directory_entries(
+        let r = make_lfn(
             "KERNEL.EFI",
             &pack_83(b"KERNEL", b"EFI"),
             0x20,

--- a/src/fat.rs
+++ b/src/fat.rs
@@ -47,17 +47,10 @@ fn make_lfn(
 
     let chk = lfn_checksum(short);
     let mut chars: Vec<u16> = name.encode_utf16().collect();
-    let num_lfn = chars.len().div_ceil(13);
-    let padded_len = num_lfn * 13;
-    chars.resize(padded_len, 0xFFFF);
-    let slot_start = (num_lfn - 1) * 13;
-    let tail_len = (chars.len() - slot_start).min(13);
-    chars[slot_start + tail_len - 1] = 0x0000;
-    for j in (slot_start + tail_len)..slot_start + 13 {
-        if j < chars.len() {
-            chars[j] = 0xFFFF;
-        }
-    }
+    let len = chars.len();
+    let num_lfn = (len + 1).div_ceil(13); // +1 for null terminator
+    chars.resize(num_lfn * 13, 0xFFFF);
+    chars[len] = 0x0000; // null-terminate immediately after the string
 
     let mut lfn = Vec::with_capacity(num_lfn * 32);
     for i in (0..num_lfn).rev() {

--- a/src/fat.rs
+++ b/src/fat.rs
@@ -72,7 +72,7 @@ fn make_lfn(
         e[9..11].copy_from_slice(&seg[4].to_le_bytes());
         e[11] = 0x0F;
         e[13] = chk;
-        for k in 0..7 {
+        for k in 0..6 {
             e[14 + k * 2..16 + k * 2].copy_from_slice(&seg[5 + k].to_le_bytes());
         }
         e[28..30].copy_from_slice(&seg[11].to_le_bytes());

--- a/src/iso/boot_catalog.rs
+++ b/src/iso/boot_catalog.rs
@@ -1,31 +1,20 @@
-// isobemak/src/iso/boot_catalog.rs
 use crate::utils::ISO_SECTOR_SIZE;
 use std::fs::File;
 use std::io::{self, Write};
 
-/// LBA of the boot catalog in the ISO.
 pub const LBA_BOOT_CATALOG: u32 = 19;
-
-/// Boot catalog constants
 pub const BOOT_CATALOG_HEADER_SIGNATURE: u16 = 0xAA55;
 pub const BOOT_CATALOG_VALIDATION_ENTRY_HEADER_ID: u8 = 1;
-/// Bootable Initial/Default entry flag (El Torito §6.2.1)
 pub const BOOT_CATALOG_BOOT_ENTRY_HEADER_ID: u8 = 0x88;
-/// Section Header entry flag – more headers follow (El Torito §7.2.4 Table 8)
 pub const BOOT_CATALOG_SECTION_HEADER_MORE_ID: u8 = 0x90;
-/// Final Section Header entry flag – last header (El Torito §7.2.4 Table 8)
 pub const BOOT_CATALOG_SECTION_HEADER_FINAL_ID: u8 = 0x91;
 pub const BOOT_CATALOG_EFI_PLATFORM_ID: u8 = 0xEF;
-pub const ID_FIELD_OFFSET: usize = 4;
-pub const BOOT_CATALOG_CHECKSUM_OFFSET: usize = 28;
+const CHECKSUM_OFFSET: usize = 28;
+const ID_OFFSET: usize = 4;
 
-/// Type of boot catalog entry.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BootCatalogEntryType {
-    /// Standard boot entry (flag=0x88 or 0x00)
     BootEntry { bootable: bool },
-    /// Section Header (flag=0x90 = more follow, 0x91 = last header)
-    /// Per El Torito §7.2.4 Table 8.
     SectionHeader { more_follow: bool },
 }
 
@@ -36,63 +25,30 @@ pub struct BootCatalogEntry {
     pub entry_type: BootCatalogEntryType,
 }
 
-/// Writes an El Torito boot catalog.
 pub fn write_boot_catalog(iso: &mut File, entries: Vec<BootCatalogEntry>) -> io::Result<()> {
     let mut catalog = [0u8; ISO_SECTOR_SIZE];
     let mut offset = 0;
 
-    // Validation Entry (32 bytes)
+    // Validation Entry
     let mut val = [0u8; 32];
     val[0] = BOOT_CATALOG_VALIDATION_ENTRY_HEADER_ID;
-    // El Torito §6.2.1: Platform ID in the Validation Entry identifies the
-    // target architecture.  0x00 = 80x86 (BIOS/UEFI CSM).
-    // Per the spec, the Validation Entry Platform ID should be 0x00 even for
-    // UEFI-only images — the boot entry system_type field (0xEF) carries the
-    // UEFI platform identification.  Setting Platform ID to 0xEF in the
-    // Validation Entry causes isoinfo to report "Arch 239 (Unknown Arch)"
-    // and may confuse Ventoy/strict firmware.
-    val[1] = 0x00; // platform_id = 0x00 (80x86) per El Torito spec
-    // ID string must always be "EL TORITO SPECIFICATION" per El Torito spec,
-    // regardless of platform ID.  Some real UEFI firmware rejects the boot
-    // catalog when this field is zero-filled.
-    let mut bytes = [0u8; 24];
-    let spec = b"EL TORITO SPECIFICATION";
-    bytes[0..spec.len()].copy_from_slice(spec);
-    let id_bytes = bytes;
-    val[ID_FIELD_OFFSET..ID_FIELD_OFFSET + 24].copy_from_slice(&id_bytes);
-
-    // No Nsect in Validation Entry (non-standard and corrupts ID string)
-
-    // Set Signature
+    val[1] = 0x00;
+    let mut id = [0u8; 24];
+    id[..23].copy_from_slice(b"EL TORITO SPECIFICATION");
+    val[ID_OFFSET..ID_OFFSET + 24].copy_from_slice(&id);
     val[30..32].copy_from_slice(&BOOT_CATALOG_HEADER_SIGNATURE.to_le_bytes());
-
-    // Checksum calculation
-    // The sum of all 16-bit words in the 32-byte entry must be zero.
-    // First, calculate the sum of all words *except* the checksum word.
-    let mut sum: u16 = 0;
-    for i in (0..32).step_by(2) {
-        // Skip the checksum field itself
-        if i == BOOT_CATALOG_CHECKSUM_OFFSET {
-            continue;
-        }
-        let word = u16::from_le_bytes(val[i..i + 2].try_into().unwrap());
-        sum = sum.wrapping_add(word);
-    }
-
-    // The checksum is the value that, when added to the sum, results in zero.
-    // This is equivalent to the two's complement of the sum.
-    let checksum = 0u16.wrapping_sub(sum);
-    val[BOOT_CATALOG_CHECKSUM_OFFSET..BOOT_CATALOG_CHECKSUM_OFFSET + 2]
-        .copy_from_slice(&checksum.to_le_bytes());
-
+    let sum: u16 = (0..32)
+        .step_by(2)
+        .filter(|&i| i != CHECKSUM_OFFSET)
+        .fold(0u16, |s, i| {
+            s.wrapping_add(u16::from_le_bytes(val[i..i + 2].try_into().unwrap()))
+        });
+    val[CHECKSUM_OFFSET..CHECKSUM_OFFSET + 2]
+        .copy_from_slice(&(0u16.wrapping_sub(sum)).to_le_bytes());
     catalog[offset..offset + 32].copy_from_slice(&val);
     offset += 32;
 
-    // Pre-compute section entry counts for each SectionHeader.
-    // A SectionHeader (flag=0x91) at position i needs to know how many
-    // non-header entries follow it in the same section (up to the next
-    // SectionHeader or end of list).  Real UEFI firmware (OVMF, InsydeH2O)
-    // uses this value to locate boot entries.
+    // Pre-compute section entry counts
     let section_counts: Vec<u16> = entries
         .iter()
         .enumerate()
@@ -100,8 +56,8 @@ pub fn write_boot_catalog(iso: &mut File, entries: Vec<BootCatalogEntry>) -> io:
             if matches!(e.entry_type, BootCatalogEntryType::SectionHeader { .. }) {
                 entries[i + 1..]
                     .iter()
-                    .take_while(|next| {
-                        !matches!(next.entry_type, BootCatalogEntryType::SectionHeader { .. })
+                    .take_while(|n| {
+                        !matches!(n.entry_type, BootCatalogEntryType::SectionHeader { .. })
                     })
                     .count() as u16
             } else {
@@ -110,74 +66,47 @@ pub fn write_boot_catalog(iso: &mut File, entries: Vec<BootCatalogEntry>) -> io:
         })
         .collect();
 
-    // Boot Entries
     for (idx, entry_data) in entries.iter().enumerate() {
-        let mut entry = [0u8; 32];
-
+        let mut e = [0u8; 32];
         let (flag, media_type) = match entry_data.entry_type {
-            BootCatalogEntryType::BootEntry { bootable } => {
-                let indicator = if bootable {
-                    BOOT_CATALOG_BOOT_ENTRY_HEADER_ID // 0x88
+            BootCatalogEntryType::BootEntry { bootable } => (
+                if bootable {
+                    BOOT_CATALOG_BOOT_ENTRY_HEADER_ID
                 } else {
-                    0x00u8
-                };
-                // Always No Emulation (0x00).  Hard Disk Emulation (4) is
-                // non-standard for UEFI and triggers "Boot media 4 (Hard Disk)"
-                // in isoinfo, which real firmware may reject.
-                (indicator, 0x00u8)
-            }
-            BootCatalogEntryType::SectionHeader { more_follow } => {
-                let indicator = if more_follow {
-                    BOOT_CATALOG_SECTION_HEADER_MORE_ID // 0x90
+                    0x00
+                },
+                0x00,
+            ),
+            BootCatalogEntryType::SectionHeader { more_follow } => (
+                if more_follow {
+                    BOOT_CATALOG_SECTION_HEADER_MORE_ID
                 } else {
-                    BOOT_CATALOG_SECTION_HEADER_FINAL_ID // 0x91
-                };
-                // Section Header byte 1 carries the platform ID
-                // (El Torito Table 8: "Platform ID").
-                (indicator, entry_data.platform_id)
-            }
+                    BOOT_CATALOG_SECTION_HEADER_FINAL_ID
+                },
+                entry_data.platform_id,
+            ),
         };
-
-        entry[0] = flag;
-        entry[1] = media_type;
-
-        // Bytes 2–3: Load segment for boot entries; "Number of section entries"
-        // for Section Header entries (El Torito §7.2.4 Table 8).
-        let field_2_3: u16 = match entry_data.entry_type {
-            BootCatalogEntryType::SectionHeader { .. } => section_counts[idx],
-            _ => 0,
+        e[0] = flag;
+        e[1] = media_type;
+        let f23 = if matches!(
+            entry_data.entry_type,
+            BootCatalogEntryType::SectionHeader { .. }
+        ) {
+            section_counts[idx]
+        } else {
+            0
         };
-        entry[2..4].copy_from_slice(&field_2_3.to_le_bytes());
-
-        // System type (byte 4):
-        //   Section Header: always 0x00 (El Torito Table 8)
-        //   Boot Entry: carry the platform_id (e.g. 0xEF for UEFI).
-        //     Without a Section Header, the entry itself must identify the
-        //     target platform so that firmware (OVMF, InsydeH2O) can find it.
-        //     With a Section Header, this field is conventionally 0x00
-        //     (the section header already defines the platform), but
-        //     setting it to the platform_id is harmless and simpler.
-        entry[4] = match entry_data.entry_type {
+        e[2..4].copy_from_slice(&f23.to_le_bytes());
+        e[4] = match entry_data.entry_type {
             BootCatalogEntryType::SectionHeader { .. } => 0x00,
             BootCatalogEntryType::BootEntry { .. } => entry_data.platform_id,
         };
-
-        // Sector count is a u16 at offset 6.
-        let sectors = entry_data.boot_image_sectors;
-        entry[6..8].copy_from_slice(&sectors.to_le_bytes());
-
-        // Load RBA is a u32 at offset 8.
-        let load_rba = entry_data.boot_image_lba;
-        entry[8..12].copy_from_slice(&load_rba.to_le_bytes());
-
-        // Bytes 12-31 are unused and already zeroed
-        catalog[offset..offset + 32].copy_from_slice(&entry);
+        e[6..8].copy_from_slice(&entry_data.boot_image_sectors.to_le_bytes());
+        e[8..12].copy_from_slice(&entry_data.boot_image_lba.to_le_bytes());
+        catalog[offset..offset + 32].copy_from_slice(&e);
         offset += 32;
     }
-
-    iso.write_all(&catalog)?;
-
-    Ok(())
+    iso.write_all(&catalog)
 }
 
 #[cfg(test)]
@@ -186,73 +115,57 @@ mod tests {
     use std::io::{Read, Seek, SeekFrom};
     use tempfile::NamedTempFile;
 
-    fn verify_checksum(validation_entry: &[u8; 32]) {
-        let mut sum: u16 = 0;
-        for i in (0..32).step_by(2) {
-            sum = sum.wrapping_add(u16::from_le_bytes([
-                validation_entry[i],
-                validation_entry[i + 1],
-            ]));
-        }
-        assert_eq!(sum, 0, "Boot catalog validation entry checksum is invalid");
+    fn verify_checksum(ve: &[u8; 32]) {
+        let s = (0..32).step_by(2).fold(0u16, |a, i| {
+            a.wrapping_add(u16::from_le_bytes([ve[i], ve[i + 1]]))
+        });
+        assert_eq!(s, 0);
     }
 
     #[test]
-    fn test_single_efi_boot_entry() -> io::Result<()> {
-        let mut temp_file = NamedTempFile::new()?;
-        let entries = vec![BootCatalogEntry {
-            platform_id: BOOT_CATALOG_EFI_PLATFORM_ID,
-            boot_image_lba: 100,
-            boot_image_sectors: 50,
-            entry_type: BootCatalogEntryType::BootEntry { bootable: true },
-        }];
-
-        write_boot_catalog(temp_file.as_file_mut(), entries)?;
-
-        let mut buffer = [0u8; ISO_SECTOR_SIZE];
-        temp_file.seek(SeekFrom::Start(0))?;
-        temp_file.read_exact(&mut buffer)?;
-
-        // Verify Validation Entry
-        let val_entry: &[u8; 32] = &buffer[0..32].try_into().unwrap();
-        assert_eq!(val_entry[0], BOOT_CATALOG_VALIDATION_ENTRY_HEADER_ID);
-        assert_eq!(val_entry[1], 0x00); // Platform ID must be 0x00 (80x86) per El Torito spec
-        assert_eq!(
-            &val_entry[30..32],
-            &BOOT_CATALOG_HEADER_SIGNATURE.to_le_bytes()
-        );
-        verify_checksum(val_entry);
-
-        // Verify Boot Entry
-        let boot_entry: &[u8; 32] = &buffer[32..64].try_into().unwrap();
-        assert_eq!(boot_entry[0], BOOT_CATALOG_BOOT_ENTRY_HEADER_ID);
-        assert_eq!(boot_entry[1], 0x00); // No Emulation
-        assert_eq!(&boot_entry[6..8], &50u16.to_le_bytes()); // Sector count
-        assert_eq!(&boot_entry[8..12], &100u32.to_le_bytes()); // LBA
-
+    fn test_single_efi() -> io::Result<()> {
+        let mut f = NamedTempFile::new()?;
+        write_boot_catalog(
+            f.as_file_mut(),
+            vec![BootCatalogEntry {
+                platform_id: BOOT_CATALOG_EFI_PLATFORM_ID,
+                boot_image_lba: 100,
+                boot_image_sectors: 50,
+                entry_type: BootCatalogEntryType::BootEntry { bootable: true },
+            }],
+        )?;
+        let mut buf = [0u8; ISO_SECTOR_SIZE];
+        f.seek(SeekFrom::Start(0))?;
+        f.read_exact(&mut buf)?;
+        let ve: &[u8; 32] = &buf[0..32].try_into().unwrap();
+        assert_eq!(ve[0], 1);
+        assert_eq!(ve[1], 0x00);
+        assert_eq!(&ve[30..32], &0xAA55u16.to_le_bytes());
+        verify_checksum(ve);
+        let be = &buf[32..64];
+        assert_eq!(be[0], 0x88);
+        assert_eq!(be[1], 0x00);
+        assert_eq!(&be[6..8], &50u16.to_le_bytes());
+        assert_eq!(&be[8..12], &100u32.to_le_bytes());
         Ok(())
     }
 
     #[test]
-    fn test_non_bootable_entry() -> io::Result<()> {
-        let mut temp_file = NamedTempFile::new()?;
-        let entries = vec![BootCatalogEntry {
-            platform_id: 0, // BIOS
-            boot_image_lba: 200,
-            boot_image_sectors: 20,
-            entry_type: BootCatalogEntryType::BootEntry { bootable: false },
-        }];
-
-        write_boot_catalog(temp_file.as_file_mut(), entries)?;
-
-        let mut buffer = [0u8; ISO_SECTOR_SIZE];
-        temp_file.seek(SeekFrom::Start(0))?;
-        temp_file.read_exact(&mut buffer)?;
-
-        // Verify Boot Entry
-        let boot_entry: &[u8; 32] = &buffer[32..64].try_into().unwrap();
-        assert_eq!(boot_entry[0], 0x00); // Not bootable
-
+    fn test_non_bootable() -> io::Result<()> {
+        let mut f = NamedTempFile::new()?;
+        write_boot_catalog(
+            f.as_file_mut(),
+            vec![BootCatalogEntry {
+                platform_id: 0,
+                boot_image_lba: 200,
+                boot_image_sectors: 20,
+                entry_type: BootCatalogEntryType::BootEntry { bootable: false },
+            }],
+        )?;
+        let mut buf = [0u8; ISO_SECTOR_SIZE];
+        f.seek(SeekFrom::Start(0))?;
+        f.read_exact(&mut buf)?;
+        assert_eq!(buf[32], 0x00);
         Ok(())
     }
 }

--- a/src/iso/builder.rs
+++ b/src/iso/builder.rs
@@ -4,51 +4,38 @@ use std::path::{Path, PathBuf};
 use tempfile::NamedTempFile;
 
 use crate::fat;
-use crate::iso::constants::disk512_to_iso;
-use crate::iso::disk_layout::DiskLayout;
-use crate::iso::layout_profile::{HiddenSectorMode, IsoLayoutProfile};
-use crate::utils::ISO_SECTOR_SIZE;
-
-// Import definitions from new modules
 use crate::iso::boot_catalog::BootCatalogEntry;
+use crate::iso::boot_catalog::LBA_BOOT_CATALOG;
 use crate::iso::boot_info::BootInfo;
 use crate::iso::builder_utils::{
     calculate_lbas, create_bios_boot_entry, create_uefi_boot_entry, create_uefi_esp_boot_entry,
     ensure_directory_path, get_file_metadata, get_file_size_in_iso, get_lba_for_path,
 };
-use crate::iso::constants::BACKUP_GPT_RESERVED_512;
+use crate::iso::constants::{BACKUP_GPT_RESERVED_512, ISO_SECTOR_SIZE};
+use crate::iso::disk_layout::DiskLayout;
 use crate::iso::fs_node::{IsoDirectory, IsoFile, IsoFsNode};
 use crate::iso::gpt::main_gpt_functions::write_gpt_structures;
-use crate::iso::gpt::partition_entry::EFI_SYSTEM_PARTITION_GUID;
-use crate::iso::gpt::partition_entry::GptPartitionEntry;
+use crate::iso::gpt::partition_entry::{EFI_SYSTEM_PARTITION_GUID, GptPartitionEntry};
 use crate::iso::iso_image::IsoImage;
 use crate::iso::iso_writer::{
     copy_files, finalize_iso, write_boot_catalog_to_iso, write_descriptors, write_directories,
 };
+use crate::iso::layout_profile::{HiddenSectorMode, IsoLayoutProfile};
 use crate::iso::mbr::create_mbr_for_gpt_hybrid;
 use crate::iso::volume_descriptor::update_total_sectors_in_pvd;
 
-/// The main builder for creating an ISO 9660 image.
 pub struct IsoBuilder {
     volume_id: Option<String>,
     root: IsoDirectory,
     boot_info: Option<BootInfo>,
-    iso_data_lba: u32, // LBA where ISO9660 filesystem data starts (QEMU/El Torito path)
+    iso_data_lba: u32,
     total_sectors: u32,
     is_isohybrid: bool,
     uefi_catalog_path: Option<String>,
-    esp_lba: Option<u32>, // LBA of the EFI System Partition image (in ISO 2048-byte sectors)
-    esp_size_sectors: Option<u32>, // Size of the EFI System Partition image in ISO sectors
+    pub esp_lba: Option<u32>,
+    pub esp_size_sectors: Option<u32>,
     profile: IsoLayoutProfile,
-    /// Disk-centric layout model: partitions (ESP) + ISO9660 region.
-    /// When set, replaces the old "ESP as ISO object" model with the
-    /// xorriso-style "ESP as disk partition" approach.
     disk_layout: Option<DiskLayout>,
-    /// ISO filesystem path of the FAT boot image (e.g. "/boot/efiboot.img").
-    /// When set, El Torito UEFI ESP boot entry and GPT ESP partition
-    /// both point to this file's extents instead of raw appended sectors.
-    /// This is the Ubuntu/xorriso convention: EFI image is an ISO file,
-    /// not a hidden raw region.
     efi_boot_image_iso_path: Option<String>,
 }
 
@@ -66,7 +53,7 @@ impl IsoBuilder {
             boot_info: None,
             iso_data_lba: 0,
             total_sectors: 0,
-            is_isohybrid: false, // Initialize new field
+            is_isohybrid: false,
             uefi_catalog_path: None,
             esp_lba: None,
             esp_size_sectors: None,
@@ -76,81 +63,42 @@ impl IsoBuilder {
         }
     }
 
-    pub fn set_volume_id(&mut self, volume_id: Option<String>) {
-        self.volume_id = volume_id;
+    pub fn set_volume_id(&mut self, v: Option<String>) {
+        self.volume_id = v;
     }
 
-    /// Adds a file to the ISO filesystem tree.
     pub fn add_file(&mut self, path_in_iso: &str, real_path: &Path) -> io::Result<()> {
         let file_name = Path::new(path_in_iso)
             .file_name()
-            .ok_or_else(|| io_error!(io::ErrorKind::InvalidInput, "Invalid file name"))?
-            .to_str()
-            .ok_or_else(|| io_error!(io::ErrorKind::InvalidInput, "Invalid file name"))?
+            .and_then(|n| n.to_str())
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "Invalid file name"))?
             .to_string();
-
         let current_dir = ensure_directory_path(&mut self.root, path_in_iso)?;
-
-        let file_metadata = get_file_metadata(real_path)?;
-        let file_size = file_metadata.len();
-
-        let file = IsoFile {
-            path: real_path.to_path_buf(),
-            size: file_size,
-            lba: 0,
-        };
-
-        current_dir
-            .children
-            .insert(file_name, IsoFsNode::File(file));
-
+        let sz = get_file_metadata(real_path)?.len();
+        current_dir.children.insert(
+            file_name,
+            IsoFsNode::File(IsoFile {
+                path: real_path.to_path_buf(),
+                size: sz,
+                lba: 0,
+            }),
+        );
         Ok(())
     }
 
-    /// Sets the boot information for the ISO.
-    pub fn set_boot_info(&mut self, boot_info: BootInfo) {
-        self.boot_info = Some(boot_info);
+    pub fn set_boot_info(&mut self, bi: BootInfo) {
+        self.boot_info = Some(bi);
+    }
+    pub fn set_profile(&mut self, p: IsoLayoutProfile) {
+        self.profile = p;
+    }
+    pub fn set_isohybrid(&mut self, v: bool) {
+        self.is_isohybrid = v;
+    }
+    pub fn set_disk_layout(&mut self, l: DiskLayout) {
+        self.disk_layout = Some(l);
     }
 
-    /// Sets the ISO layout profile for firmware compatibility.
-    pub fn set_profile(&mut self, profile: IsoLayoutProfile) {
-        self.profile = profile;
-    }
-
-    /// Sets whether the ISO should be built as an isohybrid image.
-    pub fn set_isohybrid(&mut self, is_isohybrid: bool) {
-        self.is_isohybrid = is_isohybrid;
-    }
-
-    /// Sets the disk-centric [DiskLayout] model.
-    ///
-    /// When set, the builder treats the ESP as a real disk partition
-    /// (xorriso `-append_partition` style), not an ISO9660 object.
-    pub fn set_disk_layout(&mut self, layout: DiskLayout) {
-        self.disk_layout = Some(layout);
-    }
-
-    /// Prepares the list of boot catalog entries based on boot configuration.
-    ///
-    /// El Torito boot catalog layout (matching Ubuntu/xorriso convention):
-    ///
-    ///   Validation Entry (always, 32 bytes)
-    ///     header_id=1, platform_id=0x00, ID="", key=0xAA55
-    ///
-    ///   Initial/Default Boot Entry (offset 32, flag=0x88, No Emulation, system_type=0x00)
-    ///     Points to the BIOS boot image (or ESP FAT image for hybrid).
-    ///     Real UEFI firmware (InsydeH2O, old AMI, Lenovo) ignores this
-    ///     entry and instead looks for the Section Header with platform=0xEF.
-    ///
-    ///   Section Header Entry (offset 64, flag=0x91, platform=0xEF)
-    ///     Marks the start of UEFI-specific boot entries.
-    ///     This is the structure that real firmware recognizes for UEFI boot.
-    ///     Section entries count = 1 (one boot entry follows).
-    ///
-    ///   Section Boot Entry (offset 96, flag=0x88, No Emulation, system_type=0x00)
-    ///     Points to the ESP FAT image.
-    ///     Under a Section Header with platform=0xEF, this entry is
-    ///     interpreted as a UEFI boot target.
     fn prepare_boot_entries(
         &self,
         esp_lba: Option<u32>,
@@ -160,191 +108,102 @@ impl IsoBuilder {
         let mut entries = Vec::new();
         let bi = self.boot_info.as_ref();
 
-        // Hybrid path (ESP present): Ubuntu/xorriso-compatible multi-entry layout.
         if let (Some(lba), Some(size)) = (esp_lba, esp_size_sectors) {
             if size > 0 {
-                // Entry 0: Initial/Default Boot Entry
-                // Points to the ESP FAT image (BIOS/legacy path).
                 entries.push(create_uefi_esp_boot_entry(lba, size)?);
-
-                // Entry 1: Final Section Header (flag=0x91, platform=0xEF)
-                // Tells firmware: "the following entry is UEFI".
-                // Real firmware (InsydeH2O, old AMI, Lenovo) requires this.
                 entries.push(BootCatalogEntry {
                     platform_id: BOOT_CATALOG_EFI_PLATFORM_ID,
                     boot_image_lba: 0,
                     boot_image_sectors: 0,
                     entry_type: BootCatalogEntryType::SectionHeader { more_follow: false },
                 });
-
-                // Entry 2: Section Boot Entry (under UEFI section header)
-                // Points to the ESP FAT image.
                 entries.push(create_uefi_esp_boot_entry(lba, size)?);
             }
         } else if let Some(u) = bi.and_then(|b| b.uefi_boot.as_ref()) {
-            // Non-hybrid path (CD-ROM / QEMU only): direct EFI binary entry.
             entries.push(create_uefi_boot_entry(&self.root, &u.destination_in_iso)?);
         }
-
-        // BIOS boot entry
         if let Some(b) = bi.and_then(|b| b.bios_boot.as_ref()) {
             entries.push(create_bios_boot_entry(&self.root, &b.destination_in_iso)?);
         }
-
         Ok(entries)
     }
 
-    /// Writes MBR and optionally GPT for hybrid ISOs.
-    ///
-    /// Uses the [DiskLayout] model when available (preferred), falling back
-    /// to profile-driven partition placement from `esp_size_sectors`.
-    ///
-    /// The [DiskLayout] model treats the ESP as a real disk partition,
-    /// producing the xorriso-style layout that boots on real hardware
-    /// (NEC, Insyde, old AMI, Lenovo, Panasonic). See [DiskLayout] docs.
-    ///
-    /// The total disk size passed to GPT includes `BACKUP_GPT_RESERVED_512`
-    /// extra sectors so that backup GPT structures (header + partition array)
-    /// fit at the end of the disk without overlapping ISO 9660 data.
     fn write_hybrid_structures(
         &self,
         iso_file: &mut File,
         total_lbas: u64,
         esp_size_sectors: Option<u32>,
     ) -> io::Result<()> {
-        // total_lbas is in 2048-byte ISO sectors → convert to 512-byte sectors
-        let raw_512_sectors = total_lbas.checked_mul(4).ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::InvalidInput,
-                format!(
-                    "ISO image too large: total_lbas * 4 overflows u64 ({} * 4)",
-                    total_lbas
-                ),
-            )
-        })?;
+        let raw_512 = total_lbas
+            .checked_mul(4)
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "ISO too large"))?;
+        let total_512 = ((raw_512 + BACKUP_GPT_RESERVED_512) + 3) & !3u64;
+        let total_for_mbr = u32::try_from(total_512)
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "ISO too large for MBR"))?;
 
-        // Add backup GPT reservation (33 sectors: 1 header + 32 partition entries)
-        // so that GPT structures don't overlap ISO 9660 data.
-        // Round up to a multiple of 4 (2048-byte ISO sector alignment) so that
-        // the backup GPT header at the last 512-byte LBA leaves the file
-        // 2048-aligned.  raw_512_sectors is always 4-aligned; 33 is 1 mod 4.
-        let total_512_sectors = raw_512_sectors
-            .checked_add(BACKUP_GPT_RESERVED_512)
-            .ok_or_else(|| {
-                io::Error::new(
-                    io::ErrorKind::InvalidInput,
-                    "ISO image + GPT backup too large",
-                )
-            })?;
-        // Round up to next multiple of 4 (preserves 2048-byte ISO sector alignment)
-        let total_512_sectors = (total_512_sectors + 3) & !3u64;
-
-        let total_for_mbr = if total_512_sectors <= u32::MAX as u64 {
-            total_512_sectors as u32
-        } else {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                format!(
-                    "ISO image too large for MBR ({} 512-byte sectors > u32::MAX)",
-                    total_512_sectors
-                ),
-            ));
-        };
-
-        // Determine ESP start/size in 512-byte sectors.
-        // Preferred: use file-backed EFI boot image extents (resolved from ISO
-        // filesystem tree in build()).  Convert from ISO 2048-byte LBA to 512-byte.
-        // Fallback: profile-driven fixed-position placement (legacy DiskLayout).
         let (esp_start_512, esp_size_512) =
-            if let (Some(iso_lba), Some(iso_sectors)) = (self.esp_lba, self.esp_size_sectors) {
-                // Convert ISO 2048-byte sector units to 512-byte sector units
-                let start_512 = (iso_lba as u64)
-                    .checked_mul(4)
-                    .and_then(|v| u32::try_from(v).ok());
-                let size_512 = (iso_sectors as u64)
-                    .checked_mul(4)
-                    .and_then(|v| u32::try_from(v).ok());
-                (start_512, size_512)
+            if let (Some(l), Some(s)) = (self.esp_lba, self.esp_size_sectors) {
+                (
+                    u32::try_from(l as u64 * 4).ok(),
+                    u32::try_from(s as u64 * 4).ok(),
+                )
             } else if let Some(ref layout) = self.disk_layout {
-                if let Some(esp) = layout.esp_partition() {
+                layout.esp_partition().map_or((None, None), |esp| {
                     (
                         Some(esp.start_lba_512 as u32),
                         Some(esp.size_lba_512 as u32),
                     )
-                } else {
-                    (None, None)
-                }
-            } else if let Some(esp_size_iso) = esp_size_sectors {
-                (
-                    Some(self.profile.esp_alignment_lba_512),
-                    Some(esp_size_iso * 4),
-                )
+                })
+            } else if let Some(sz) = esp_size_sectors {
+                (Some(self.profile.esp_alignment_lba_512), Some(sz * 4))
             } else {
                 (None, None)
             };
 
-        // --- MBR (always written) ---
         iso_file.seek(SeekFrom::Start(0))?;
-        let mbr = create_mbr_for_gpt_hybrid(
+        create_mbr_for_gpt_hybrid(
             total_for_mbr,
             self.is_isohybrid,
             esp_start_512,
             esp_size_512,
-        )?;
-        mbr.write_to(iso_file)?;
+        )?
+        .write_to(iso_file)?;
 
-        // --- GPT (profile-controlled, uses DiskLayout when available) ---
         if self.profile.use_gpt {
-            let mut gpt_partitions: Vec<GptPartitionEntry> = Vec::new();
-
-            // GPT partition 1: ISO 9660 data (type 0x0700 = "ISO9660" per Ubuntu/xorriso).
-            // Covers the ISO 9660 data region including ESP in the middle.
-            // This matches Ubuntu's GPT layout where the ISO9660 partition
-            // is the first GPT entry.
-            let iso9660_guid = "EBD0A0A2-B9E5-4433-87C0-68B6B72699C7";
-            let iso9660_uuid = uuid::Uuid::new_v4().to_string();
-            let iso_start: u64 = 34;
-            let iso_end: u64 = total_512_sectors.saturating_sub(34);
-            if iso_end > iso_start {
-                let iso_partition = GptPartitionEntry::new(
-                    iso9660_guid,
-                    &iso9660_uuid,
-                    iso_start,
-                    iso_end,
+            let mut parts = Vec::new();
+            let start: u64 = 34;
+            let end: u64 = total_512.saturating_sub(34);
+            if end > start {
+                parts.push(GptPartitionEntry::new(
+                    "EBD0A0A2-B9E5-4433-87C0-68B6B72699C7",
+                    &uuid::Uuid::new_v4().to_string(),
+                    start,
+                    end,
                     "ISO9660",
                     0,
-                );
-                gpt_partitions.push(iso_partition);
+                ));
             }
-
-            // GPT partition 2: EFI System Partition
-            if let (Some(start_512), Some(size_512)) = (esp_start_512, esp_size_512) {
-                let esp_end_512 = start_512.saturating_add(size_512).saturating_sub(1);
-                if esp_end_512 > start_512 {
-                    let esp_uuid = uuid::Uuid::new_v4().to_string();
-                    let esp_attributes: u64 = 1; // bit 0: System Partition
-                    let esp_partition = GptPartitionEntry::new(
+            if let (Some(s), Some(sz)) = (esp_start_512, esp_size_512) {
+                let e = s.saturating_add(sz).saturating_sub(1);
+                if e > s {
+                    parts.push(GptPartitionEntry::new(
                         EFI_SYSTEM_PARTITION_GUID,
-                        &esp_uuid,
-                        start_512 as u64,
-                        esp_end_512 as u64,
+                        &uuid::Uuid::new_v4().to_string(),
+                        s as u64,
+                        e as u64,
                         "EFI System Partition",
-                        esp_attributes,
-                    );
-                    gpt_partitions.push(esp_partition);
+                        1,
+                    ));
                 }
             }
-
-            if !gpt_partitions.is_empty() {
-                write_gpt_structures(iso_file, total_512_sectors, &gpt_partitions)?;
+            if !parts.is_empty() {
+                write_gpt_structures(iso_file, total_512, &parts)?;
             }
         }
-
         iso_file.sync_data()?;
         Ok(())
     }
 
-    /// Builds the ISO file based on the configured files and boot information.
     pub fn build(
         &mut self,
         iso_file: &mut File,
@@ -354,233 +213,117 @@ impl IsoBuilder {
     ) -> io::Result<()> {
         self.esp_lba = esp_lba;
         self.esp_size_sectors = esp_size_sectors;
-        // iso_file is now passed directly
 
-        // Physical layout (ISO 2048-byte sectors) for isohybrid:
-        //
-        //   LBA 0-15:    system area (MBR/GPT written later by write_hybrid_structures)
-        //   LBA 16:      Primary Volume Descriptor (fixed by ISO 9660 spec)
-        //   LBA 17:      Boot Record Volume Descriptor (El Torito)
-        //   LBA 18:      Volume Descriptor Set Terminator
-        //   LBA 19:      El Torito Boot Catalog
-        //   LBA 20-1023: padding / alignment gap (ensures ESP starts at 2 MiB = LBA 1024)
-        //   LBA 1024..1024+esp_size-1: EFI System Partition (FAT image)
-        //   LBA 1024+esp_size..:       ISO9660 directory records and file data
-        //
-        // Volume descriptors and boot catalog are written at fixed LBAs
-        // (16-19), independent of iso_data_lba.
-        // File data starts at iso_data_lba = ESP_START_LBA + esp_size,
-        // ensuring ISO9660 metadata never overlaps with the ESP region.
-
-        let boot_catalog_lba = 19;
-
-        // iso_data_lba: start of ISO9660 directory records and file contents.
-        // Always begins right after VDs+boot catalog (LBA 20).
-        // The EFI boot image is a regular ISO file (not raw appended sectors),
-        // so no fixed-position ESP reservation is needed.
-        self.iso_data_lba = if let Some(ref layout) = self.disk_layout {
-            layout.iso_region.data_start_lba
-        } else {
-            boot_catalog_lba + 1
-        };
-        iso_file.seek(SeekFrom::Start(
-            (self.iso_data_lba as u64) * ISO_SECTOR_SIZE as u64,
-        ))?;
-
-        // Calculate LBAs for all files and directories. This also updates self.iso_data_lba to the end of the filesystem data.
+        self.iso_data_lba = self
+            .disk_layout
+            .as_ref()
+            .map_or(LBA_BOOT_CATALOG + 1, |l| l.iso_region.data_start_lba);
+        iso_file.seek(SeekFrom::Start(self.iso_data_lba as u64 * ISO_SECTOR_SIZE))?;
         calculate_lbas(&mut self.iso_data_lba, &mut self.root)?;
 
-        // --- Resolve ESP LBA/size from the ISO filesystem tree ---
-        // Preferred: use the file-backed EFI boot image (Ubuntu/xorriso convention).
-        // Fallback: use explicitly provided esp_lba/esp_size_sectors (legacy).
-        let (resolved_esp_lba, resolved_esp_size_sectors) =
-            if let Some(ref iso_path) = self.efi_boot_image_iso_path {
-                let lba = get_lba_for_path(&self.root, iso_path)?;
-                let size_bytes = get_file_size_in_iso(&self.root, iso_path)?;
-                let sectors = size_bytes.div_ceil(ISO_SECTOR_SIZE as u64) as u32;
-                (Some(lba), Some(sectors))
-            } else {
-                (esp_lba, esp_size_sectors)
-            };
-        // Store resolved values so write_hybrid_structures can use them
-        self.esp_lba = resolved_esp_lba;
-        self.esp_size_sectors = resolved_esp_size_sectors;
+        let (resolved_lba, resolved_size) = if let Some(ref ip) = self.efi_boot_image_iso_path {
+            (
+                Some(get_lba_for_path(&self.root, ip)?),
+                Some(get_file_size_in_iso(&self.root, ip)?.div_ceil(ISO_SECTOR_SIZE) as u32),
+            )
+        } else {
+            (esp_lba, esp_size_sectors)
+        };
+        self.esp_lba = resolved_lba;
+        self.esp_size_sectors = resolved_size;
 
-        // Write volume descriptors at fixed ISO 9660 positions
-        // (LBA 16=PVD, 17=BRVD, 18=Terminator).
         write_descriptors(
             iso_file,
             self.volume_id.as_deref(),
             self.root.lba,
             self.iso_data_lba,
         )?;
-
-        let boot_entries =
-            self.prepare_boot_entries(resolved_esp_lba, resolved_esp_size_sectors)?;
-        write_boot_catalog_to_iso(iso_file, boot_catalog_lba, boot_entries)?;
-
-        // Write directory records and copy file contents.
+        write_boot_catalog_to_iso(
+            iso_file,
+            LBA_BOOT_CATALOG,
+            self.prepare_boot_entries(resolved_lba, resolved_size)?,
+        )?;
         write_directories(iso_file, &self.root, self.root.lba)?;
         copy_files(iso_file, &self.root)?;
-
-        // Finalize the ISO by padding and updating the total sector count in the PVD
         finalize_iso(iso_file, &mut self.total_sectors)?;
 
-        // If not isohybrid, clear the initial reserved sectors (MBR area).
-
-        // Now that total_sectors is known, write MBR and GPT structures if hybrid
         if self.is_isohybrid {
             self.write_hybrid_structures(iso_file, self.total_sectors as u64, esp_size_sectors)?;
-
-            // write_hybrid_structures appended backup GPT (33×512 = 16896 bytes)
-            // to the end of the file.  16896 is not a multiple of 2048, so the
-            // file is now larger than when finalize_iso wrote the PVD and is no
-            // longer 2048-aligned.  Re-pad to 2048, then read the actual file
-            // size and update the PVD so that Ventoy and other tools see correct
-            // ISO9660 metadata.
             let pos = iso_file.seek(SeekFrom::End(0))?;
-            let remainder = pos % ISO_SECTOR_SIZE as u64;
-            if remainder != 0 {
-                let padding = ISO_SECTOR_SIZE as u64 - remainder;
-                io::copy(&mut io::repeat(0).take(padding), iso_file)?;
+            let rem = pos % ISO_SECTOR_SIZE;
+            if rem != 0 {
+                io::copy(&mut io::repeat(0).take(ISO_SECTOR_SIZE - rem), iso_file)?;
             }
-            let final_size = iso_file.seek(SeekFrom::End(0))?;
-            let final_total_sectors_u64 = final_size.div_ceil(ISO_SECTOR_SIZE as u64);
-            let final_total_sectors = u32::try_from(final_total_sectors_u64).map_err(|_| {
+            let total = u32::try_from(iso_file.seek(SeekFrom::End(0))?.div_ceil(ISO_SECTOR_SIZE))
+                .map_err(|_| {
                 io::Error::new(
                     io::ErrorKind::InvalidInput,
-                    "ISO image too large after appending GPT backup structures",
+                    "ISO too large after GPT backup",
                 )
             })?;
-            update_total_sectors_in_pvd(iso_file, final_total_sectors)?;
-            self.total_sectors = final_total_sectors;
+            update_total_sectors_in_pvd(iso_file, total)?;
+            self.total_sectors = total;
         }
-
         Ok(())
     }
 }
 
-/// High-level function to create an ISO 9660 image from a structured `IsoImage`.
-/// Returns the path to the generated ISO, the temporary FAT image holder (if created),
-/// and the `File` handle to the ISO itself.
 pub fn build_iso(
     iso_path: &Path,
     image: &IsoImage,
     is_isohybrid: bool,
 ) -> io::Result<(PathBuf, Option<NamedTempFile>, File, Option<u32>)> {
-    // Added Option<u32> for logical_fat_size_512_sectors
-    let mut iso_builder = IsoBuilder::new();
-    iso_builder.set_profile(image.layout_profile.clone());
-    iso_builder.set_volume_id(image.volume_id.clone());
-    iso_builder.set_isohybrid(is_isohybrid);
+    let mut b = IsoBuilder::new();
+    b.set_profile(image.layout_profile.clone());
+    b.set_volume_id(image.volume_id.clone());
+    b.set_isohybrid(is_isohybrid);
 
-    let mut temp_fat_file_holder: Option<NamedTempFile> = None;
-    let mut _temp_grub_cfg_file_holder: Option<NamedTempFile> = None; // Hold grub.cfg temp file
-    let mut logical_fat_size_512_sectors: Option<u32> = None; // Declare here
-
-    // Create the ISO file
+    let mut fat_holder: Option<NamedTempFile> = None;
+    let mut _grub_holder: Option<NamedTempFile> = None;
+    let mut fat_size_512: Option<u32> = None;
     let mut iso_file = File::create(iso_path)?;
 
-    if let Some(uefi_boot) = &image.boot_info.uefi_boot {
-        iso_builder.uefi_catalog_path = Some(uefi_boot.destination_in_iso.clone());
-
+    if let Some(uefi) = &image.boot_info.uefi_boot {
+        b.uefi_catalog_path = Some(uefi.destination_in_iso.clone());
         if is_isohybrid {
-            let temp_fat_file = NamedTempFile::new()?;
-            let path = temp_fat_file.path().to_path_buf();
-            temp_fat_file_holder = Some(temp_fat_file);
+            let tf = NamedTempFile::new()?;
+            let p = tf.path().to_path_buf();
+            fat_holder = Some(tf);
 
-            // Build the list of files for the FAT image
-            let mut fat_files: Vec<(&str, &Path)> = Vec::new();
-            fat_files.push(("BOOTX64.EFI", &uefi_boot.boot_image));
-            fat_files.push(("KERNEL.EFI", &uefi_boot.kernel_image));
-            // Add any additional EFI boot files (e.g. GRUBX64.EFI)
-            for (dest_name, source_path) in &uefi_boot.additional_efi_boot_files {
-                fat_files.push((dest_name.as_str(), source_path.as_path()));
+            let mut ff: Vec<(&str, &Path)> = vec![
+                ("BOOTX64.EFI", uefi.boot_image.as_path()),
+                ("KERNEL.EFI", uefi.kernel_image.as_path()),
+            ];
+            for (dn, sp) in &uefi.additional_efi_boot_files {
+                ff.push((dn, sp));
             }
-            // If grub.cfg content is specified, create a temporary file and add it
-            let grub_cfg_path_buf: Option<PathBuf> =
-                if let Some(grub_cfg) = &uefi_boot.grub_cfg_content {
-                    let mut grub_temp = NamedTempFile::new()?;
-                    write!(grub_temp, "{}", grub_cfg)?;
-                    let path = grub_temp.path().to_path_buf();
-                    _temp_grub_cfg_file_holder = Some(grub_temp);
-                    Some(path)
-                } else {
-                    None
-                };
-            if let Some(ref grub_path) = grub_cfg_path_buf {
-                fat_files.push(("grub.cfg", grub_path));
+            let _grub_path: Option<PathBuf>;
+            if let Some(cfg) = &uefi.grub_cfg_content {
+                let mut t = NamedTempFile::new()?;
+                write!(t, "{}", cfg)?;
+                _grub_path = Some(t.path().to_path_buf());
+                _grub_holder = Some(t);
+                ff.push(("grub.cfg", _grub_path.as_ref().unwrap()));
             }
-            // ESP hidden sectors: profile-controlled (Zero for emulator, PartitionOffset for hardware).
-            let esp_hidden_sectors = match iso_builder.profile.hidden_sectors_mode {
+            let hidden = match b.profile.hidden_sectors_mode {
                 HiddenSectorMode::Zero => 0,
-                HiddenSectorMode::PartitionOffset => iso_builder.profile.esp_alignment_lba_512,
+                HiddenSectorMode::PartitionOffset => b.profile.esp_alignment_lba_512,
             };
-            let size_512_sectors = fat::create_fat_image(&path, &fat_files, esp_hidden_sectors)?;
-            logical_fat_size_512_sectors = Some(size_512_sectors);
-
-            // Convert logical FAT size from 512-byte sectors to ISO 2048-byte sectors
-            let _calculated_esp_size_iso_sectors = size_512_sectors.div_ceil(4); // 1 ISO sector = 4 × 512-byte sectors
-
-            // Derive ISO-sector ESP LBA from profile alignment.
-            let esp_lba_iso_profile = disk512_to_iso(iso_builder.profile.esp_alignment_lba_512);
-
-            // Construct DiskLayout: ESP is a real disk partition, not an ISO object.
-            // This matches xorriso `-append_partition` behavior and is required
-            // for real hardware UEFI boot (NEC/Insyde/old AMI).
-            let _disk_layout = DiskLayout::from_partition_params(
-                iso_builder.profile.esp_alignment_lba_512,
-                Some(size_512_sectors),
-                // ISO data starts at the aligned ESP position.
-                // The ESP image is added as a file and will occupy this space.
-                esp_lba_iso_profile,
-            );
-
-            // Ubuntu/xorriso convention: EFI boot image is a regular ISO file,
-            // not a hidden raw region.  Add the FAT image to the ISO tree so
-            // that El Torito, GPT, and xorriso can discover it as a normal file.
-            // El Torito and GPT will resolve the file's LBA and size after
-            // calculate_lbas() in build().
-            // Use relative paths (no leading "/") so that ensure_directory_path
-            // creates "boot" under the ISO root, not a literal "/" directory.
-            iso_builder.efi_boot_image_iso_path = Some("boot/efiboot.img".to_string());
-            iso_builder.add_file("boot/efiboot.img", &path)?;
+            fat_size_512 = Some(fat::create_fat_image(&p, &ff, hidden)?);
+            b.efi_boot_image_iso_path = Some("boot/efiboot.img".into());
+            b.add_file("boot/efiboot.img", &p)?;
         }
     }
 
-    // Add all regular files to the ISO builder
-    for file in &image.files {
-        iso_builder.add_file(&file.destination, &file.source)?;
+    for f in &image.files {
+        b.add_file(&f.destination, &f.source)?;
     }
-
-    // Handle BIOS boot image (add to ISO tree)
-    if let Some(bios_boot_info) = &image.boot_info.bios_boot {
-        iso_builder.add_file(
-            &bios_boot_info.destination_in_iso,
-            &bios_boot_info.boot_image,
-        )?;
+    if let Some(bios) = &image.boot_info.bios_boot {
+        b.add_file(&bios.destination_in_iso, &bios.boot_image)?;
     }
-
-    // Set boot information for the ISO builder
-    iso_builder.set_boot_info(image.boot_info.clone());
-
-    // Build the ISO using the mutable iso_file
-    iso_builder.build(
-        &mut iso_file,
-        iso_path,
-        iso_builder.esp_lba,
-        iso_builder.esp_size_sectors,
-    )?;
-
-    // The iso_file is already the final_iso_file
-    let final_iso_file = iso_file;
-
-    Ok((
-        iso_path.to_path_buf(),
-        temp_fat_file_holder,
-        final_iso_file,
-        logical_fat_size_512_sectors, // Return this value
-    ))
+    b.set_boot_info(image.boot_info.clone());
+    b.build(&mut iso_file, iso_path, b.esp_lba, b.esp_size_sectors)?;
+    Ok((iso_path.to_path_buf(), fat_holder, iso_file, fat_size_512))
 }
 
 #[cfg(test)]
@@ -592,101 +335,83 @@ mod tests {
     #[test]
     fn test_add_file() -> io::Result<()> {
         let mut builder = IsoBuilder::new();
-        let temp_file = NamedTempFile::new()?;
-        let temp_path = temp_file.path().to_path_buf();
-
-        // Add a root file
-        builder.add_file("root.txt", &temp_path)?;
+        let tp = NamedTempFile::new()?.into_temp_path();
+        builder.add_file("root.txt", &tp)?;
         assert!(builder.root.children.contains_key("root.txt"));
-
-        // Add a nested file
-        builder.add_file("dir1/nested.txt", &temp_path)?;
-        let dir1 = match builder.root.children.get("dir1") {
-            Some(IsoFsNode::Directory(dir)) => dir,
-            _ => panic!("dir1 was not created as a directory"),
+        builder.add_file("dir1/nested.txt", &tp)?;
+        match builder.root.children.get("dir1") {
+            Some(IsoFsNode::Directory(d)) => assert!(d.children.contains_key("nested.txt")),
+            _ => panic!(),
         };
-        assert!(dir1.children.contains_key("nested.txt"));
-
         Ok(())
     }
 
     #[test]
     fn test_calculate_lbas() -> io::Result<()> {
         let mut root = IsoDirectory::new();
-        let mut current_lba = 20; // Start at a known LBA
-
-        // Add a directory and a file
+        let mut lba = 20;
         let mut subdir = IsoDirectory::new();
-        let file1 = IsoFile {
-            path: PathBuf::new(),
-            size: 1000,
-            lba: 0,
-        }; // Less than 1 sector
-        let file2 = IsoFile {
-            path: PathBuf::new(),
-            size: 3000,
-            lba: 0,
-        }; // 2 sectors
-        subdir
-            .children
-            .insert("file2.txt".to_string(), IsoFsNode::File(file2));
+        subdir.children.insert(
+            "file2.txt".into(),
+            IsoFsNode::File(IsoFile {
+                path: PathBuf::new(),
+                size: 3000,
+                lba: 0,
+            }),
+        );
+        root.children.insert(
+            "file1.txt".into(),
+            IsoFsNode::File(IsoFile {
+                path: PathBuf::new(),
+                size: 1000,
+                lba: 0,
+            }),
+        );
         root.children
-            .insert("file1.txt".to_string(), IsoFsNode::File(file1));
-        root.children
-            .insert("subdir".to_string(), IsoFsNode::Directory(subdir));
-
-        calculate_lbas(&mut current_lba, &mut root)?;
-
-        // Expected LBA assignments:
-        // root: 20
-        // file1.txt: 21 (1 sector)
-        // subdir: 22
-        // file2.txt: 23 (2 sectors)
-        // final lba: 25
-
+            .insert("subdir".into(), IsoFsNode::Directory(subdir));
+        calculate_lbas(&mut lba, &mut root)?;
         assert_eq!(root.lba, 20);
-        match root.children.get("file1.txt") {
-            Some(IsoFsNode::File(f)) => assert_eq!(f.lba, 21),
-            _ => panic!("file1.txt not found"),
-        }
-        let (subdir_lba, file2_lba) = match root.children.get("subdir") {
-            Some(IsoFsNode::Directory(d)) => {
-                let file2_lba = match d.children.get("file2.txt") {
-                    Some(IsoFsNode::File(f)) => f.lba,
-                    _ => panic!("file2.txt not found"),
-                };
-                (d.lba, file2_lba)
-            }
-            _ => panic!("subdir not found"),
+        assert_eq!(
+            root.children
+                .get("file1.txt")
+                .and_then(|n| if let IsoFsNode::File(f) = n {
+                    Some(f.lba)
+                } else {
+                    None
+                }),
+            Some(21)
+        );
+        let (sl, fl) = match root.children.get("subdir") {
+            Some(IsoFsNode::Directory(d)) => (
+                d.lba,
+                d.children.get("file2.txt").and_then(|n| {
+                    if let IsoFsNode::File(f) = n {
+                        Some(f.lba)
+                    } else {
+                        None
+                    }
+                }),
+            ),
+            _ => panic!(),
         };
-        assert_eq!(subdir_lba, 22);
-        assert_eq!(file2_lba, 23);
-        assert_eq!(current_lba, 25);
-
+        assert_eq!(sl, 22);
+        assert_eq!(fl, Some(23));
+        assert_eq!(lba, 25);
         Ok(())
     }
 
     #[test]
     fn test_get_path_helpers() -> io::Result<()> {
         let mut builder = IsoBuilder::new();
-        let mut temp_file = NamedTempFile::new()?;
-        temp_file.write_all(b"some data")?;
-        let temp_path = temp_file.path().to_path_buf();
-
-        builder.add_file("A/B/C.txt", &temp_path)?;
+        let mut tf = NamedTempFile::new()?;
+        tf.write_all(b"some data")?;
+        let tp = tf.into_temp_path();
+        builder.add_file("A/B/C.txt", &tp)?;
         builder.iso_data_lba = 20;
         calculate_lbas(&mut builder.iso_data_lba, &mut builder.root)?;
-
-        let lba = crate::iso::builder_utils::get_lba_for_path(&builder.root, "A/B/C.txt")?;
-        let size = crate::iso::builder_utils::get_file_size_in_iso(&builder.root, "A/B/C.txt")?;
-
-        // root dir: 20, A: 21, B: 22, C.txt: 23
-        assert_eq!(lba, 23);
-        assert_eq!(size, 9);
-
-        // Test not found
-        assert!(crate::iso::builder_utils::get_lba_for_path(&builder.root, "A/D.txt").is_err());
-
+        assert_eq!(get_lba_for_path(&builder.root, "A/B/C.txt")?, 23);
+        assert_eq!(get_file_size_in_iso(&builder.root, "A/B/C.txt")?, 9);
+        assert!(get_lba_for_path(&builder.root, "A/D.txt").is_err());
         Ok(())
     }
 }

--- a/src/iso/builder_utils.rs
+++ b/src/iso/builder_utils.rs
@@ -6,312 +6,153 @@ use crate::iso::boot_catalog::{
 };
 use crate::iso::fs_node::{IsoDirectory, IsoFsNode};
 use crate::utils::ISO_SECTOR_SIZE;
+
 const EL_TORITO_SECTOR_SIZE: u64 = 512;
-/// Enum representing different boot types for cleaner boot entry creation
-#[derive(Clone, Copy)]
-pub enum BootType {
-    Bios,
-    Uefi,
-    UefiEsp,
-}
 
-impl BootType {
-    fn platform_id(self) -> u8 {
-        match self {
-            BootType::Bios => 0x00,
-            BootType::Uefi | BootType::UefiEsp => BOOT_CATALOG_EFI_PLATFORM_ID,
-        }
-    }
-
-    fn description(self) -> &'static str {
-        match self {
-            BootType::Bios => "BIOS boot",
-            BootType::Uefi => "UEFI boot",
-            BootType::UefiEsp => "UEFI ESP",
-        }
-    }
-}
-
-/// Calculates the Logical Block Addresses (LBAs) for all files and directories.
 pub fn calculate_lbas(current_lba: &mut u32, dir: &mut IsoDirectory) -> io::Result<()> {
     dir.lba = *current_lba;
     *current_lba += 1;
-
-    let mut sorted_children: Vec<_> = dir.children.iter_mut().collect();
-    sorted_children.sort_by_key(|(name, _)| *name);
-
-    for (_, node) in sorted_children {
+    let mut sorted: Vec<_> = dir.children.iter_mut().collect();
+    sorted.sort_by_key(|(name, _)| *name);
+    for (_, node) in sorted {
         match node {
             IsoFsNode::File(file) => {
                 file.lba = *current_lba;
-                let sectors = file.size.div_ceil(ISO_SECTOR_SIZE as u64) as u32;
-                *current_lba += sectors;
+                *current_lba += file.size.div_ceil(ISO_SECTOR_SIZE as u64) as u32;
             }
-            IsoFsNode::Directory(subdir) => {
-                calculate_lbas(current_lba, subdir)?;
-            }
+            IsoFsNode::Directory(subdir) => calculate_lbas(current_lba, subdir)?,
         }
     }
     Ok(())
 }
 
-/// Helper to find the LBA for a given path in the ISO filesystem.
-pub fn get_lba_for_path(root: &IsoDirectory, path: &str) -> io::Result<u32> {
-    match get_node_for_path(root, path)? {
-        IsoFsNode::File(file) => Ok(file.lba),
-        IsoFsNode::Directory(_) => Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            format!("Path is a directory, not a file: {}", path),
-        )),
-    }
-}
-
-/// Helper to find the size for a given path in the ISO filesystem.
-pub fn get_file_size_in_iso(root: &IsoDirectory, path: &str) -> io::Result<u64> {
-    match get_node_for_path(root, path)? {
-        IsoFsNode::File(file) => Ok(file.size),
-        IsoFsNode::Directory(_) => Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            format!("Path is a directory, not a file: {}", path),
-        )),
-    }
-}
-
-/// Context for path operations, avoiding repeated parsing
-struct PathContext<'a> {
-    components: Vec<std::path::Component<'a>>,
-    path_str: &'a str,
-}
-
-impl<'a> PathContext<'a> {
-    fn new(path: &'a str) -> Self {
-        Self {
-            components: Path::new(path).components().collect(),
-            path_str: path,
-        }
-    }
-
-    fn validate_all(&self) -> io::Result<()> {
-        validate_path_components(Path::new(self.path_str))
-    }
-}
-
-/// Helper to find the IsoFsNode for a given path in the ISO filesystem.
 fn get_node_for_path<'a>(root: &'a IsoDirectory, path: &str) -> io::Result<&'a IsoFsNode> {
-    let path_ctx = PathContext::new(path);
-    path_ctx.validate_all()?;
-
-    let mut current_node = root;
-
-    for (i, component) in path_ctx.components.iter().enumerate() {
-        let component_name = ensure_path_component!(component, path_ctx.path_str);
-
-        if i == path_ctx.components.len() - 1 {
-            // Last component, this is the target node
-            return current_node
-                .children
-                .get(component_name)
-                .ok_or_else(|| io_error!(io::ErrorKind::NotFound, "Path not found: {}", path));
-        } else {
-            // Intermediate component, must be a directory
-            match current_node.children.get(component_name) {
-                Some(IsoFsNode::Directory(dir)) => current_node = dir,
-                _ => {
-                    return Err(io_error!(
-                        io::ErrorKind::NotFound,
-                        "Directory not found in path: {}",
-                        path
-                    ));
-                }
+    for c in Path::new(path).components() {
+        c.as_os_str()
+            .to_str()
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "Invalid path"))?;
+    }
+    let mut current = root;
+    let components: Vec<_> = Path::new(path).components().collect();
+    for (i, comp) in components.iter().enumerate() {
+        let name = comp.as_os_str().to_str().unwrap();
+        if i == components.len() - 1 {
+            return current.children.get(name).ok_or_else(|| {
+                io::Error::new(io::ErrorKind::NotFound, format!("Path not found: {path}"))
+            });
+        }
+        match current.children.get(name) {
+            Some(IsoFsNode::Directory(d)) => current = d,
+            _ => {
+                return Err(io::Error::new(
+                    io::ErrorKind::NotFound,
+                    format!("Directory not found: {path}"),
+                ));
             }
         }
     }
-    // This part should be unreachable if components is not empty
-    Err(io_error!(
+    Err(io::Error::new(
         io::ErrorKind::NotFound,
-        "Path not found: {}",
-        path
+        format!("Path not found: {path}"),
     ))
 }
 
-/// Calculate the number of sectors needed for a given file size
-pub fn calculate_sectors_from_size(file_size: u64) -> u32 {
-    file_size.div_ceil(ISO_SECTOR_SIZE as u64) as u32
-}
-
-/// Validate that a boot image size is suitable for the boot catalog
-pub fn validate_boot_image_size(size: u64, max_size: u64, image_type: &str) -> io::Result<()> {
-    if size > max_size {
-        return Err(io_error!(
+pub fn get_lba_for_path(root: &IsoDirectory, path: &str) -> io::Result<u32> {
+    match get_node_for_path(root, path)? {
+        IsoFsNode::File(f) => Ok(f.lba),
+        IsoFsNode::Directory(_) => Err(io::Error::new(
             io::ErrorKind::InvalidInput,
-            "{} image is too large for the boot catalog ({} > {})",
-            image_type,
-            size,
-            max_size
-        ));
+            format!("Path is a directory: {path}"),
+        )),
     }
-    Ok(())
 }
 
-/// Generic function to create any boot entry type (returns result directly)
-pub fn create_boot_entry_generic(
-    boot_type: BootType,
-    root: &IsoDirectory,
-    destination_path: Option<&str>,
-    esp_lba: Option<u32>,
-    esp_size_sectors: Option<u32>,
-) -> io::Result<BootCatalogEntry> {
-    Ok(BootCatalogEntry {
-        platform_id: boot_type.platform_id(),
-        boot_image_lba: match boot_type {
-            BootType::Bios | BootType::Uefi => {
-                let path = destination_path.ok_or_else(|| {
-                    io_error!(
-                        io::ErrorKind::InvalidInput,
-                        "Path required for {} boot",
-                        boot_type.description()
-                    )
-                })?;
-                get_lba_for_path(root, path)?
-            }
-            BootType::UefiEsp => {
-                let lba = esp_lba.ok_or_else(|| {
-                    io_error!(
-                        io::ErrorKind::InvalidInput,
-                        "ESP LBA required for UEFI ESP boot"
-                    )
-                })?;
-                // El Torito Load RBA uses the medium's sector size (2048 bytes for CD-ROM).
-                // QEMU/OVMF boots via El Torito on CD-ROM → 2048-byte sector units.
-                // Real USB hardware ignores El Torito and boots via GPT+ESP instead,
-                // so the Load RBA is only relevant for QEMU and stays in ISO sectors.
-                lba
-            }
-        },
-        boot_image_sectors: match boot_type {
-            BootType::Bios | BootType::Uefi => {
-                let path = destination_path.ok_or_else(|| {
-                    io_error!(
-                        io::ErrorKind::InvalidInput,
-                        "Path required for {} boot",
-                        boot_type.description()
-                    )
-                })?;
-                let size = get_file_size_in_iso(root, path)?;
-                let sectors = size.div_ceil(EL_TORITO_SECTOR_SIZE).max(1);
-                validate_boot_image_size(sectors, u16::MAX as u64, boot_type.description())?;
-                sectors as u16
-            }
-            BootType::UefiEsp => {
-                // UEFI no-emulation: sector_count is ignored by most firmware
-                // (OVMF, GRUB, xorisso).  Setting it to 0 is the canonical
-                // value for UEFI El Torito no-emulation entries and prevents
-                // strict parsers (Ventoy) from rejecting the image.
-                //
-                // The ESP FAT image is already accessible via the Load RBA
-                // field (entry[8..12]) and the GPT partition table, so
-                // sector_count is not needed for boot.
-                if esp_size_sectors.is_none() {
-                    return Err(io_error!(
-                        io::ErrorKind::InvalidInput,
-                        "ESP size required for UEFI ESP boot"
-                    ));
-                }
-                0u16
-            }
-        },
-        entry_type: BootCatalogEntryType::BootEntry { bootable: true },
-    })
+pub fn get_file_size_in_iso(root: &IsoDirectory, path: &str) -> io::Result<u64> {
+    match get_node_for_path(root, path)? {
+        IsoFsNode::File(f) => Ok(f.size),
+        IsoFsNode::Directory(_) => Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("Path is a directory: {path}"),
+        )),
+    }
 }
 
-/// Create a boot catalog entry for BIOS boot
-pub fn create_bios_boot_entry(
-    root: &IsoDirectory,
-    destination_path: &str,
-) -> io::Result<BootCatalogEntry> {
-    create_boot_entry_generic(BootType::Bios, root, Some(destination_path), None, None)
-}
-
-/// Create a boot catalog entry for UEFI boot
-pub fn create_uefi_boot_entry(
-    root: &IsoDirectory,
-    destination_path: &str,
-) -> io::Result<BootCatalogEntry> {
-    create_boot_entry_generic(BootType::Uefi, root, Some(destination_path), None, None)
-}
-
-/// Create a boot catalog entry for UEFI ESP partition
-/// `esp_lba` is in 2048-byte ISO sector units (the ISO filesystem LBA).
-/// El Torito Load RBA uses the medium's sector size (2048 bytes for CD-ROM),
-/// so the LBA stays in ISO sectors. GPT partition table separately records
-/// the ESP with 512-byte sector LBA values in `builder.rs`.
-pub fn create_uefi_esp_boot_entry(
-    esp_lba: u32,
-    esp_size_sectors: u32,
-) -> io::Result<BootCatalogEntry> {
-    create_boot_entry_generic(
-        BootType::UefiEsp,
-        &IsoDirectory::new(),
-        None,
-        Some(esp_lba), // 2048-byte ISO sectors (El Torito uses medium sector size)
-        Some(esp_size_sectors),
-    )
-}
-
-/// Get file metadata with consistent error handling
 pub fn get_file_metadata(path: &Path) -> io::Result<std::fs::Metadata> {
     std::fs::metadata(path).map_err(|e| {
-        io_error!(
+        io::Error::new(
             io::ErrorKind::NotFound,
-            "Failed to get file metadata for {}: {}",
-            path.display(),
-            e
+            format!("Failed to get metadata for {}: {e}", path.display()),
         )
     })
 }
 
-/// Navigate to a directory by path, creating intermediate directories if they don't exist.
 pub fn ensure_directory_path<'a>(
     root: &'a mut IsoDirectory,
     path: &str,
 ) -> io::Result<&'a mut IsoDirectory> {
     let components: Vec<_> = Path::new(path).components().collect();
-    let mut current_dir = root;
-
-    for component in components.iter().take(components.len().saturating_sub(1)) {
-        let component_name = component
+    let mut current = root;
+    for comp in components.iter().take(components.len().saturating_sub(1)) {
+        let name = comp
             .as_os_str()
             .to_str()
-            .ok_or_else(|| io_error!(io::ErrorKind::InvalidInput, "Invalid path component"))?;
-        current_dir = match current_dir
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "Invalid path component"))?;
+        current = match current
             .children
-            .entry(component_name.to_string())
+            .entry(name.to_string())
             .or_insert_with(|| IsoFsNode::Directory(IsoDirectory::new()))
         {
-            IsoFsNode::Directory(dir) => dir,
+            IsoFsNode::Directory(d) => d,
             IsoFsNode::File(_) => {
-                return Err(io_error!(
+                return Err(io::Error::new(
                     io::ErrorKind::AlreadyExists,
-                    "Path component '{}' is a file, expected directory",
-                    component_name
+                    format!("Path component '{name}' is a file"),
                 ));
             }
         };
     }
-
-    Ok(current_dir)
+    Ok(current)
 }
 
-/// Validate path components with consistent error handling
-pub fn validate_path_components(path: &Path) -> io::Result<()> {
-    for component in path.components() {
-        component.as_os_str().to_str().ok_or_else(|| {
-            io_error!(
-                io::ErrorKind::InvalidInput,
-                "Invalid path component: {:?}",
-                component
-            )
-        })?;
+fn mk_boot_entry(platform_id: u8, lba: u32, sectors: u16) -> BootCatalogEntry {
+    BootCatalogEntry {
+        platform_id,
+        boot_image_lba: lba,
+        boot_image_sectors: sectors,
+        entry_type: BootCatalogEntryType::BootEntry { bootable: true },
     }
-    Ok(())
+}
+
+pub fn create_bios_boot_entry(root: &IsoDirectory, path: &str) -> io::Result<BootCatalogEntry> {
+    let lba = get_lba_for_path(root, path)?;
+    let sz = get_file_size_in_iso(root, path)?;
+    let sectors = sz.div_ceil(EL_TORITO_SECTOR_SIZE).max(1);
+    if sectors > u16::MAX as u64 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "BIOS boot image too large",
+        ));
+    }
+    Ok(mk_boot_entry(0x00, lba, sectors as u16))
+}
+
+pub fn create_uefi_boot_entry(root: &IsoDirectory, path: &str) -> io::Result<BootCatalogEntry> {
+    let lba = get_lba_for_path(root, path)?;
+    let sz = get_file_size_in_iso(root, path)?;
+    let sectors = sz.div_ceil(EL_TORITO_SECTOR_SIZE).max(1);
+    if sectors > u16::MAX as u64 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "UEFI boot image too large",
+        ));
+    }
+    Ok(mk_boot_entry(
+        BOOT_CATALOG_EFI_PLATFORM_ID,
+        lba,
+        sectors as u16,
+    ))
+}
+
+pub fn create_uefi_esp_boot_entry(esp_lba: u32, _esp_size: u32) -> io::Result<BootCatalogEntry> {
+    Ok(mk_boot_entry(BOOT_CATALOG_EFI_PLATFORM_ID, esp_lba, 0))
 }

--- a/src/iso/disk_layout.rs
+++ b/src/iso/disk_layout.rs
@@ -1,118 +1,46 @@
-// src/iso/disk_layout.rs
-//! Disk-centric layout model for isohybrid ISO images.
-//!
-//! Instead of treating the ESP as an ISO9660-embedded blob ("ISO-centric"),
-//! this module models the disk as:
-//!
-//! ```text
-//! Disk
-//!  ├─ MBR/GPT
-//!  ├─ ESP partition (real FAT partition, not an ISO object)
-//!  └─ ISO9660 region
-//!       └─ El Torito (direct EFI binary, not FAT image)
-//! ```
-//!
-//! This matches how real UEFI firmware sees a USB drive and is the
-//! approach used by xorriso (`-append_partition`).
-
-/// A physical disk partition (e.g., EFI System Partition).
-///
-/// This is a **real** partition in MBR/GPT, not an ISO9660 filesystem object.
-/// Firmware (especially on real hardware like NEC/Insyde) looks for this
-/// when the medium is treated as USB-HDD.
 #[derive(Debug, Clone)]
 pub struct Partition {
-    /// Partition start LBA in 512-byte sectors.
     pub start_lba_512: u64,
-    /// Partition size in 512-byte sectors.
     pub size_lba_512: u64,
 }
-
-/// The ISO9660 filesystem region within the disk layout.
-///
-/// Contains volume descriptors, El Torito boot catalog, directory records,
-/// and file data. The El Torito catalog references the EFI binary directly
-/// (not a FAT image), for QEMU/OVMF CD-ROM emulation.
 #[derive(Debug, Clone)]
 pub struct IsoRegion {
-    /// LBA (in 2048-byte ISO sectors) where ISO9660 file data begins
-    /// (after volume descriptors and boot catalog).
     pub data_start_lba: u32,
-    /// Total ISO9660 sectors (filled in during build).
     pub total_sectors: u32,
 }
-
-/// Complete disk layout: partitions + ISO9660 region.
-///
-/// This is the central model that replaces the old "ISO-with-embedded-ESP"
-/// approach. The key insight: ESP is a **disk partition**, not an ISO object.
 #[derive(Debug, Clone)]
 pub struct DiskLayout {
-    /// Disk partitions (e.g., ESP). In MBR/GPT order.
     pub partitions: Vec<Partition>,
-    /// ISO9660 filesystem region.
     pub iso_region: IsoRegion,
 }
-
-/// How UEFI boot is exposed to firmware.
-///
-/// The fundamental split recognized by xorriso and now isobemak:
-///
-/// - **El Torito direct EFI**: QEMU/OVMF boots via CD-ROM emulation,
-///   reading the EFI binary directly from the ISO9660 filesystem through
-///   the El Torito boot catalog.
-///
-/// - **ESP partition**: Real USB hardware (NEC, Insyde, old AMI, Lenovo,
-///   Panasonic) ignores El Torito and boots via MBR→GPT→ESP, looking for
-///   a real FAT partition with `EFI/BOOT/BOOTX64.EFI`.
-///
-/// Both strategies coexist in a hybrid ISO: El Torito for emulators,
-/// ESP partition for real hardware.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UefiBootStrategy {
-    /// Expose EFI binary directly via El Torito boot catalog entry.
-    /// Primary path for QEMU/OVMF which boots via CD-ROM emulation.
     ElToritoDirectEfi,
-    /// Expose via a real ESP partition in MBR/GPT.
-    /// Primary path for real USB-HDD hardware.
     EspPartition,
 }
 
 impl DiskLayout {
-    /// Create a disk layout from partition placement parameters.
-    ///
-    /// `esp_alignment_lba_512`: where the ESP starts (in 512-byte sectors).
-    /// `esp_size_512`: ESP size in 512-byte sectors (None if no ESP).
-    /// `iso_data_start_lba`: ISO9660 data start in 2048-byte sectors.
-    pub fn from_partition_params(
-        esp_alignment_lba_512: u32,
-        esp_size_512: Option<u32>,
-        iso_data_start_lba: u32,
-    ) -> Self {
-        let mut partitions = Vec::new();
-        if let Some(size) = esp_size_512
-            && size > 0
-        {
-            partitions.push(Partition {
-                start_lba_512: esp_alignment_lba_512 as u64,
-                size_lba_512: size as u64,
-            });
+    pub fn from_partition_params(esp_align: u32, esp_size: Option<u32>, iso_data_lba: u32) -> Self {
+        let mut parts = Vec::new();
+        if let Some(sz) = esp_size {
+            if sz > 0 {
+                parts.push(Partition {
+                    start_lba_512: esp_align as u64,
+                    size_lba_512: sz as u64,
+                });
+            }
         }
         Self {
-            partitions,
+            partitions: parts,
             iso_region: IsoRegion {
-                data_start_lba: iso_data_start_lba,
-                total_sectors: 0, // filled in during finalize_iso
+                data_start_lba: iso_data_lba,
+                total_sectors: 0,
             },
         }
     }
-
-    /// Returns the EFI System Partition if present.
     pub fn esp_partition(&self) -> Option<&Partition> {
         self.partitions.first()
     }
-
-    /// Returns true if the disk has an ESP partition for hardware UEFI boot.
     pub fn has_esp(&self) -> bool {
         self.esp_partition().is_some()
     }
@@ -121,27 +49,21 @@ impl DiskLayout {
 #[cfg(test)]
 mod tests {
     use super::*;
-
     #[test]
-    fn test_disk_layout_with_esp() {
-        let layout = DiskLayout::from_partition_params(2048, Some(32768), 24);
-        assert!(layout.has_esp());
-        let esp = layout.esp_partition().unwrap();
-        assert_eq!(esp.start_lba_512, 2048);
-        assert_eq!(esp.size_lba_512, 32768);
-        assert_eq!(layout.iso_region.data_start_lba, 24);
+    fn test_with_esp() {
+        let l = DiskLayout::from_partition_params(2048, Some(32768), 24);
+        assert!(l.has_esp());
+        let e = l.esp_partition().unwrap();
+        assert_eq!(e.start_lba_512, 2048);
+        assert_eq!(e.size_lba_512, 32768);
+        assert_eq!(l.iso_region.data_start_lba, 24);
     }
-
     #[test]
-    fn test_disk_layout_without_esp() {
-        let layout = DiskLayout::from_partition_params(0, None, 20);
-        assert!(!layout.has_esp());
-        assert!(layout.esp_partition().is_none());
+    fn test_no_esp() {
+        assert!(!DiskLayout::from_partition_params(0, None, 20).has_esp());
     }
-
     #[test]
-    fn test_disk_layout_empty_esp() {
-        let layout = DiskLayout::from_partition_params(2048, Some(0), 24);
-        assert!(!layout.has_esp());
+    fn test_zero_esp() {
+        assert!(!DiskLayout::from_partition_params(2048, Some(0), 24).has_esp());
     }
 }

--- a/src/iso/gpt/main_gpt_functions.rs
+++ b/src/iso/gpt/main_gpt_functions.rs
@@ -1,294 +1,168 @@
-use crc32fast::Hasher;
-use std::io::{self, Seek, SeekFrom, Write};
-use std::mem;
-
 use crate::iso::gpt::header::GptHeader;
 use crate::iso::gpt::partition_entry::GptPartitionEntry;
+use crc32fast::Hasher;
+use std::io::{self, Seek, SeekFrom, Write};
 
-/// Calculates the CRC32 for a GPT header.
-/// The CRC covers exactly `header.header_size` bytes, per UEFI spec.
-fn calculate_header_crc32(header: &mut GptHeader) -> u32 {
-    header.header_crc32 = 0; // Zero out CRC field for calculation
-    let header_bytes = header.to_bytes();
-    let size = header.header_size as usize;
-    let header_data_for_crc = &header_bytes[..size];
+fn crc_header(h: &mut GptHeader) -> u32 {
+    h.header_crc32 = 0;
+    let b = h.to_bytes();
     let mut hasher = Hasher::new();
-    hasher.update(header_data_for_crc);
+    hasher.update(&b[..h.header_size as usize]);
     hasher.finalize()
 }
 
-/// Calculates the CRC32 for the partition entry array.
-fn calculate_partition_array_crc32(
-    partitions: &[GptPartitionEntry],
-    num_partition_entries: u32,
-    partition_entry_size: u32,
-) -> u32 {
-    let mut partition_array_bytes =
-        vec![0u8; (num_partition_entries * partition_entry_size) as usize];
-    let mut offset = 0;
-    for partition in partitions {
-        let partition_slice = partition.to_bytes();
-        partition_array_bytes[offset..offset + mem::size_of::<GptPartitionEntry>()]
-            .copy_from_slice(&partition_slice);
-        offset += mem::size_of::<GptPartitionEntry>();
+fn crc_parts(parts: &[GptPartitionEntry], n: u32, es: u32) -> u32 {
+    let mut arr = vec![0u8; (n * es) as usize];
+    let mut off = 0;
+    for p in parts {
+        let pb = p.to_bytes();
+        arr[off..off + pb.len()].copy_from_slice(&pb);
+        off += pb.len();
     }
     let mut hasher = Hasher::new();
-    hasher.update(&partition_array_bytes);
+    hasher.update(&arr);
     hasher.finalize()
 }
 
-/// Writes the primary GPT header and partition array.
-fn write_primary_gpt_structures<W: Write + Seek>(
-    writer: &mut W,
-    header: &GptHeader,
-    partitions: &[GptPartitionEntry],
-    num_partition_entries: u32,
-    partition_entry_size: u32,
-    partition_array_lba: u64,
+fn write_primary<W: Write + Seek>(
+    w: &mut W,
+    h: &GptHeader,
+    parts: &[GptPartitionEntry],
+    n: u32,
+    es: u32,
+    alba: u64,
 ) -> io::Result<()> {
-    // Write Main GPT Header
-    writer.seek(SeekFrom::Start(512))?; // LBA 1
-    header.write_to(writer)?;
-
-    // Write Partition Entries
-    writer.seek(SeekFrom::Start(partition_array_lba * 512))?; // LBA 2
-    for partition in partitions {
-        partition.write_to(writer)?;
+    w.seek(SeekFrom::Start(512))?;
+    h.write_to(w)?;
+    w.seek(SeekFrom::Start(alba * 512))?;
+    for p in parts {
+        p.write_to(w)?;
     }
-    // Pad remaining partition entries with zeros
-    for _ in partitions.len()..num_partition_entries as usize {
-        writer.write_all(&vec![0u8; partition_entry_size as usize])?;
+    for _ in parts.len()..n as usize {
+        w.write_all(&vec![0u8; es as usize])?;
     }
     Ok(())
 }
 
-/// Writes the backup GPT header and partition array.
-fn write_backup_gpt_structures<W: Write + Seek>(
-    writer: &mut W,
-    header: &GptHeader,
-    partitions: &[GptPartitionEntry],
-    num_partition_entries: u32,
-    partition_entry_size: u32,
-    total_lbas: u64,
+fn write_backup<W: Write + Seek>(
+    w: &mut W,
+    h: &GptHeader,
+    parts: &[GptPartitionEntry],
+    n: u32,
+    es: u32,
+    total: u64,
 ) -> io::Result<()> {
-    // Calculate partition array size in 512-byte sectors.
-    // Example: 128 entries * 128 bytes = 16384 bytes → 32 sectors.
-    let partition_array_sectors =
-        ((num_partition_entries as u64) * (partition_entry_size as u64)).div_ceil(512);
-
-    let mut backup_header = *header;
-    backup_header.current_lba = total_lbas - 1;
-    backup_header.backup_lba = 1;
-
-    // Backup GPT: backup header at last LBA, partition array ends right before it.
-    // partition_entry_lba must point to the start of the backup partition array.
-    // backup_array_start = total_lbas - 1 - partition_array_sectors
-    backup_header.partition_entry_lba = total_lbas
-        .saturating_sub(1)
-        .saturating_sub(partition_array_sectors);
-
-    backup_header.header_crc32 = calculate_header_crc32(&mut backup_header);
-
-    // Write backup GPT header at the last LBA.
-    writer.seek(SeekFrom::Start((total_lbas - 1) * 512))?;
-    backup_header.write_to(writer)?;
-
-    // Write backup partition entries right before the backup header.
-    let backup_array_start_byte = (total_lbas - 1 - partition_array_sectors) * 512;
-    writer.seek(SeekFrom::Start(backup_array_start_byte))?;
-    for partition in partitions {
-        partition.write_to(writer)?;
+    let arr_sectors = ((n as u64) * (es as u64)).div_ceil(512);
+    let mut bh = *h;
+    bh.current_lba = total - 1;
+    bh.backup_lba = 1;
+    bh.partition_entry_lba = total.saturating_sub(1).saturating_sub(arr_sectors);
+    bh.header_crc32 = crc_header(&mut bh);
+    w.seek(SeekFrom::Start((total - 1) * 512))?;
+    bh.write_to(w)?;
+    w.seek(SeekFrom::Start((total - 1 - arr_sectors) * 512))?;
+    for p in parts {
+        p.write_to(w)?;
     }
-    // Pad remaining backup partition entries with zeros
-    for _ in partitions.len()..num_partition_entries as usize {
-        writer.write_all(&vec![0u8; partition_entry_size as usize])?;
+    for _ in parts.len()..n as usize {
+        w.write_all(&vec![0u8; es as usize])?;
     }
     Ok(())
 }
 
 pub fn write_gpt_structures<W: Write + Seek>(
-    writer: &mut W,
+    w: &mut W,
     total_lbas: u64,
     partitions: &[GptPartitionEntry],
 ) -> io::Result<()> {
-    let num_partition_entries: u32 = 128; // Standard number of entries
-    let partition_entry_size = mem::size_of::<GptPartitionEntry>() as u32;
-    let partition_array_lba: u64 = 2; // LBA 2 for partition array
-
-    // Main GPT Header
-    let mut header = GptHeader::new(
-        total_lbas,
-        partition_array_lba,
-        num_partition_entries,
-        partition_entry_size,
-    );
-
-    header.partition_array_crc32 =
-        calculate_partition_array_crc32(partitions, num_partition_entries, partition_entry_size);
-    header.header_crc32 = calculate_header_crc32(&mut header);
-
-    write_primary_gpt_structures(
-        writer,
-        &header,
-        partitions,
-        num_partition_entries,
-        partition_entry_size,
-        partition_array_lba,
-    )?;
-    write_backup_gpt_structures(
-        writer,
-        &header,
-        partitions,
-        num_partition_entries,
-        partition_entry_size,
-        total_lbas,
-    )?;
-
-    Ok(())
+    let n: u32 = 128;
+    let es = std::mem::size_of::<GptPartitionEntry>() as u32;
+    let alba: u64 = 2;
+    let mut h = GptHeader::new(total_lbas, alba, n, es);
+    h.partition_array_crc32 = crc_parts(partitions, n, es);
+    h.header_crc32 = crc_header(&mut h);
+    write_primary(w, &h, partitions, n, es, alba)?;
+    write_backup(w, &h, partitions, n, es, total_lbas)
 }
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use crate::iso::constants::ESP_START_LBA_512;
     use crate::iso::gpt::partition_entry::EFI_SYSTEM_PARTITION_GUID;
-
-    use super::*;
     use std::io::Cursor;
+    use std::mem;
 
-    // Helper to read a packed struct safely from a byte slice.
-    fn read_struct<T: Copy>(slice: &[u8], offset: usize) -> T {
-        let size = mem::size_of::<T>();
-        let sub_slice = &slice[offset..offset + size];
-        // Using `read_unaligned` is safer and more direct for reading from a byte
-        // slice that may not have the alignment required for type `T`.
-        unsafe { (sub_slice.as_ptr() as *const T).read_unaligned() }
+    fn read_struct<T: Copy>(s: &[u8], off: usize) -> T {
+        unsafe { (s[off..off + mem::size_of::<T>()].as_ptr() as *const T).read_unaligned() }
     }
 
     #[test]
     fn test_gpt_header_new() {
-        let total_lbas = 2048;
-        let header = GptHeader::new(total_lbas, 2, 128, 128);
-
-        assert_eq!(&header.signature, b"EFI PART");
-        let revision = header.revision;
-        assert_eq!(revision, 0x00010000);
-        let current_lba = header.current_lba;
-        assert_eq!(current_lba, 1);
-        let backup_lba = header.backup_lba;
-        assert_eq!(backup_lba, total_lbas - 1);
-        // GPT first_usable_lba = partition_entry_lba + partition_array_sectors
-        // = 2 + 32 = 34 (independent of ESP_START_LBA, which is a filesystem-level constant)
-        let first_usable = header.first_usable_lba;
-        assert_eq!(first_usable, 34);
+        let h = GptHeader::new(2048, 2, 128, 128);
+        assert_eq!(&h.signature, b"EFI PART");
+        assert_eq!({ h.revision }, 0x00010000);
+        assert_eq!({ h.current_lba }, 1);
+        assert_eq!({ h.backup_lba }, 2047);
+        assert_eq!({ h.first_usable_lba }, 34);
     }
 
     #[test]
     fn test_gpt_partition_entry_new() {
-        let p_guid = "C12A7328-F81F-11D2-BA4B-00A0C93EC93B";
-        let u_guid = "A2A0D0D0-039B-42A0-BA42-A0D0D0D0D0A0";
-        let name = "EFI System Partition";
-        let entry = GptPartitionEntry::new(p_guid, u_guid, ESP_START_LBA_512 as u64, 2048, name, 0);
-
-        let starting_lba = entry.starting_lba;
-        assert_eq!(starting_lba, ESP_START_LBA_512 as u64);
-        let ending_lba = entry.ending_lba;
-        assert_eq!(ending_lba, 2048);
-
-        let mut expected_name = [0u16; 36];
-        for (i, c) in name.encode_utf16().enumerate() {
-            expected_name[i] = c;
-        }
-        let partition_name = entry.partition_name;
-        assert_eq!(partition_name, expected_name);
+        let e = GptPartitionEntry::new(
+            "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+            "A2A0D0D0-039B-42A0-BA42-A0D0D0D0D0A0",
+            ESP_START_LBA_512 as u64,
+            2048,
+            "EFI System Partition",
+            0,
+        );
+        assert_eq!({ e.starting_lba }, ESP_START_LBA_512 as u64);
+        assert_eq!({ e.ending_lba }, 2048);
     }
 
     #[test]
-    fn test_write_gpt_structures() -> io::Result<()> {
-        let total_lbas = 4096;
-        let num_partition_entries = 128;
-        let partition_entry_size = mem::size_of::<GptPartitionEntry>();
-        let mut disk = Cursor::new(vec![0; total_lbas as usize * 512]);
-
-        let partitions = vec![GptPartitionEntry::new(
+    fn test_write_gpt() -> io::Result<()> {
+        let total = 4096u64;
+        let n = 128;
+        let es = mem::size_of::<GptPartitionEntry>();
+        let mut disk = Cursor::new(vec![0; total as usize * 512usize]);
+        let parts = vec![GptPartitionEntry::new(
             EFI_SYSTEM_PARTITION_GUID,
-            &"A2A0D0D0-039B-42A0-BA42-A0D0D0D0D0A0".to_string(),
+            &"A2A0D0D0-039B-42A0-BA42-A0D0D0D0D0A0",
             2048,
             4095,
-            "Test Partition",
+            "Test",
             0,
         )];
+        write_gpt_structures(&mut disk, total, &parts)?;
+        let d = disk.into_inner();
 
-        write_gpt_structures(&mut disk, total_lbas, &partitions)?;
+        let ph: GptHeader = read_struct(&d, 512);
+        assert_eq!(&ph.signature, b"EFI PART");
+        assert_eq!({ ph.header_size } as usize, 92);
+        let mut hb = ph.to_bytes();
+        hb[16..20].copy_from_slice(&[0; 4]);
+        let mut hh = Hasher::new();
+        hh.update(&hb[..92]);
+        assert_eq!({ ph.header_crc32 }, hh.finalize());
 
-        let disk_bytes = disk.into_inner();
+        let arr_offset = 2 * 512;
+        let arr_size = n * es;
+        let mut hh2 = Hasher::new();
+        hh2.update(&d[arr_offset..arr_offset + arr_size]);
+        assert_eq!({ ph.partition_array_crc32 }, hh2.finalize());
 
-        // Verify Primary Header (read as packed, then copy fields to locals)
-        let primary_header: GptHeader = read_struct(&disk_bytes, 512);
-        let sig_primary = { primary_header.signature };
-        assert_eq!(&sig_primary, b"EFI PART");
+        let bh: GptHeader = read_struct(&d, (total as usize - 1) * 512);
+        assert_eq!(&bh.signature, b"EFI PART");
+        assert_eq!({ bh.current_lba }, total - 1);
+        assert_eq!({ bh.backup_lba }, 1);
 
-        // CRC must cover header_size bytes, per UEFI spec
-        let header_size = { primary_header.header_size } as usize;
-        assert_eq!(header_size, 92, "GPT header_size must be 92");
-
-        let mut header_bytes = primary_header.to_bytes();
-        header_bytes[16..20].copy_from_slice(&[0; 4]);
-        let header_data_for_crc = &header_bytes[0..header_size];
-
-        let mut hasher = Hasher::new();
-        hasher.update(header_data_for_crc);
-        let calculated_crc = hasher.finalize();
-
-        let stored_crc = { primary_header.header_crc32 };
-        assert_eq!(stored_crc, calculated_crc, "Primary header CRC32 mismatch");
-
-        // Verify Primary Partition Array position
-        let partition_array_sectors =
-            ((num_partition_entries as u64) * (partition_entry_size as u64)).div_ceil(512);
-        assert_eq!(partition_array_sectors, 32, "128*128/512 = 32 sectors");
-        let primary_part_entry_lba = { primary_header.partition_entry_lba };
-        assert_eq!(primary_part_entry_lba, 2);
-
-        // Verify Partition Array CRC
-        let partition_array_offset = 2 * 512;
-        let partition_array_size = num_partition_entries * partition_entry_size;
-        let partition_array_bytes =
-            &disk_bytes[partition_array_offset..partition_array_offset + partition_array_size];
-        let mut hasher = Hasher::new();
-        hasher.update(partition_array_bytes);
-        let calculated_array_crc = hasher.finalize();
-        let stored_array_crc = { primary_header.partition_array_crc32 };
-        assert_eq!(
-            stored_array_crc, calculated_array_crc,
-            "Partition array CRC32 mismatch"
-        );
-
-        // Verify Backup Header at last LBA
-        let backup_header_offset = ((total_lbas - 1) * 512) as usize;
-        let backup_header: GptHeader = read_struct(&disk_bytes, backup_header_offset);
-        let sig_backup = { backup_header.signature };
-        assert_eq!(&sig_backup, b"EFI PART");
-        let backup_current_lba = { backup_header.current_lba };
-        assert_eq!(backup_current_lba, total_lbas - 1);
-        let backup_backup_lba = { backup_header.backup_lba };
-        assert_eq!(backup_backup_lba, 1);
-
-        // Verify Backup Partition Entry array is right before the backup header.
-        let expected_backup_array_start_lba = total_lbas - 1 - partition_array_sectors;
-        let backup_part_entry_lba = { backup_header.partition_entry_lba };
-        assert_eq!(
-            backup_part_entry_lba, expected_backup_array_start_lba,
-            "Backup partition_entry_lba must point to start of backup partition array"
-        );
-
-        // Verify backup partition array content
-        let backup_array_byte_offset = (expected_backup_array_start_lba * 512) as usize;
-        let backup_entry: GptPartitionEntry = read_struct(&disk_bytes, backup_array_byte_offset);
-        let be_starting_lba = { backup_entry.starting_lba };
-        let be_ending_lba = { backup_entry.ending_lba };
-        assert_eq!(be_starting_lba, 2048);
-        assert_eq!(be_ending_lba, 4095);
-
+        let arr_sectors = (n as u64 * es as u64).div_ceil(512);
+        let b_arr = (total as usize - 1 - arr_sectors as usize) * 512;
+        let be: GptPartitionEntry = read_struct(&d, b_arr);
+        assert_eq!({ be.starting_lba }, 2048);
+        assert_eq!({ be.ending_lba }, 4095);
         Ok(())
     }
 }

--- a/src/iso/gpt/main_gpt_functions.rs
+++ b/src/iso/gpt/main_gpt_functions.rs
@@ -38,8 +38,9 @@ fn write_primary<W: Write + Seek>(
     for p in parts {
         p.write_to(w)?;
     }
+    let zero = vec![0u8; es as usize];
     for _ in parts.len()..n as usize {
-        w.write_all(&vec![0u8; es as usize])?;
+        w.write_all(&zero)?;
     }
     Ok(())
 }

--- a/src/iso/layout_profile.rs
+++ b/src/iso/layout_profile.rs
@@ -1,79 +1,32 @@
 use crate::iso::disk_layout::UefiBootStrategy;
 
-/// ISO layout profile for firmware compatibility.
-///
-/// Separates "UEFI spec compliant" settings from "broken firmware workaround" settings,
-/// following the xorriso/GRUB approach of dual-boot-path and per-firmware tuning.
 #[derive(Debug, Clone)]
 pub struct IsoLayoutProfile {
-    /// Whether to write GPT header and partition entries.
-    /// - On: QEMU/OVMF, modern UEFI firmware
-    /// - Off: NEC/Insyde/old AMI that fail when GPT is present (xorriso MBR-only hybrid)
     pub use_gpt: bool,
-
-    /// El Torito boot catalog UEFI entry configuration.
     pub eltorito_mode: ElToritoMode,
-
-    /// EFI System Partition placement strategy.
     pub esp_mode: EspMode,
-
-    /// ESP start LBA in 512-byte sector units (alignment).
-    /// UEFI spec recommends 1 MiB (2048), some firmware expects 2 MiB (4096).
     pub esp_alignment_lba_512: u32,
-
-    /// MBR partition table layout.
     pub mbr_mode: MbrMode,
-
-    /// FAT BPB hidden_sectors policy.
     pub hidden_sectors_mode: HiddenSectorMode,
-
-    /// UEFI boot strategy: El Torito direct EFI vs. ESP partition.
-    /// Determines whether the primary boot path is via CD-ROM emulation
-    /// (QEMU/OVMF) or via a real disk partition (USB-HDD hardware).
     pub uefi_boot_strategy: UefiBootStrategy,
 }
 
-/// How the El Torito catalog exposes the UEFI boot target.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ElToritoMode {
-    /// Two entries: Entry 0 (bootable) → direct EFI binary in ISO9660,
-    ///              Entry 1 (non-bootable) → ESP FAT image.
-    /// Matches xorriso `-e EFI/BOOT/BOOTX64.EFI -append_partition 2 0xef esp.img`.
     Both,
-
-    /// Single entry: Entry 0 (bootable) → direct EFI binary only.
-    /// ESP FAT image is still present for USB-HDD boot path but not referenced from El Torito.
     DirectEfiOnly,
 }
-
-/// EFI System Partition placement strategy.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EspMode {
-    /// ESP is written inside the ISO image at a fixed offset,
-    /// referenced by MBR partition entry (and optionally GPT).
-    /// This is the standard isohybrid layout used by xorriso.
     AppendedPartition,
 }
-
-/// MBR partition table layout.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MbrMode {
-    /// Two partitions: Entry 0 = type 0x83 (Linux/ISO9660, covers whole disk),
-    ///                 Entry 1 = type 0xEF (EFI System Partition).
-    /// Matches xorriso MBR-only hybrid layout.
     HybridLinuxEsp,
 }
-
-/// FAT BPB hidden_sectors policy.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HiddenSectorMode {
-    /// hidden_sectors = 0.
-    /// QEMU/OVMF passes even with zero; avoids confusing firmware that rejects
-    /// FAT images with non-zero hidden sectors inside an El Torito CD context.
     Zero,
-    /// hidden_sectors = ESP partition start LBA (in 512-byte sectors).
-    /// Required by NEC/Insyde/old AMI firmware for FAT geometry validation
-    /// when the medium is treated as USB-HDD.
     PartitionOffset,
 }
 
@@ -84,50 +37,24 @@ impl Default for IsoLayoutProfile {
 }
 
 impl IsoLayoutProfile {
-    /// QEMU/OVMF / modern UEFI firmware profile.
-    ///
-    /// - GPT enabled (UEFI spec compliant)
-    /// - El Torito: both direct EFI binary and ESP image entries
-    /// - ESP at 2 MiB alignment (4096 512-byte sectors)
-    /// - MBR: hybrid Linux+ESP
-    /// - hidden_sectors: partition offset
-    /// - UEFI boot: El Torito direct EFI (primary for CD-ROM emulation)
     pub fn emulator() -> Self {
         Self {
             use_gpt: true,
             eltorito_mode: ElToritoMode::Both,
             esp_mode: EspMode::AppendedPartition,
-            esp_alignment_lba_512: 4096, // 2 MiB (matches ESP_START_LBA_512)
+            esp_alignment_lba_512: 4096,
             mbr_mode: MbrMode::HybridLinuxEsp,
             hidden_sectors_mode: HiddenSectorMode::PartitionOffset,
             uefi_boot_strategy: UefiBootStrategy::ElToritoDirectEfi,
         }
     }
-
-    /// Real hardware profile (NEC, Insyde, old AMI, Lenovo, Panasonic).
-    ///   - GPT enabled (protective MBR + GPT, matching xorriso)
-    ///   - ESP at 2 MiB alignment (4096 512-byte sectors)
-    ///   - El Torito: BIOS + UEFI entries
-    ///   - FAT BPB: heads=64, spt=32, hidden_sectors=0
-    ///   - UEFI boot: ESP partition (primary for USB-HDD hardware path)
     pub fn hardware() -> Self {
         Self {
             use_gpt: true,
             eltorito_mode: ElToritoMode::Both,
             esp_mode: EspMode::AppendedPartition,
-            esp_alignment_lba_512: 4096, // 2 MiB (matches ESP_START_LBA_512)
+            esp_alignment_lba_512: 4096,
             mbr_mode: MbrMode::HybridLinuxEsp,
-            // hidden_sectors MUST be 0 for real hardware compatibility.
-            //
-            // UEFI firmware locates the ESP via GPT partition entries (which
-            // provide the absolute starting LBA).  When hidden_sectors is
-            // non-zero, some firmware (InsydeH2O, older AMI) adds it on top
-            // of the GPT-provided offset, causing a double offset that
-            // breaks FAT cluster chain traversal, resulting in
-            // "No bootfile found for UEFI!".
-            //
-            // This matches the behaviour of other bootable
-            // ISOs that successfully boot on real hardware.
             hidden_sectors_mode: HiddenSectorMode::Zero,
             uefi_boot_strategy: UefiBootStrategy::EspPartition,
         }

--- a/src/iso/mbr.rs
+++ b/src/iso/mbr.rs
@@ -1,50 +1,25 @@
-// src/iso/mbr.rs
-
 use std::io::{self, Seek, Write};
 
-/// Disk geometry used for CHS calculations.
-/// Must match the BPB geometry written in fat.rs (heads=64, spt=32).
-const CHS_HEADS: u32 = 64;
-const CHS_SPT: u32 = 32;
-const CHS_SECTORS_PER_CYLINDER: u32 = CHS_HEADS * CHS_SPT; // 2048
+const H: u32 = 64;
+const SPT: u32 = 32;
+const SPC: u32 = H * SPT;
+const MAX_CYL: u32 = 1023;
 
-/// Maximum cylinder value for CHS addressing with the configured geometry.
-/// When cylinder exceeds this value, CHS is saturated (0xFF, 0xFF, 0xFF).
-const CHS_MAX_CYL: u32 = 1023;
-
-/// Encode an LBA into a 3-byte CHS tuple `[head, sector_cyl, cyl_low]`
-/// using H=64, S=32 geometry.
-///
-/// CHS encoding (per MBR / INT 13h):
-///   byte 0 = head
-///   byte 1 = sector (bits 0–5) | cylinder bits 8–9 (bits 6–7)
-///   byte 2 = cylinder bits 0–7
-///
-/// LBA 0 is a valid address (the MBR itself) and maps to cylinder 0,
-/// head 0, sector 1 (INT 13h sectors are 1-indexed).
-///
-/// When `lba` exceeds the CHS-addressable range for the configured
-/// geometry (H=64, SPT=32), all fields are saturated to their
-/// maximum values.
 fn lba_to_chs(lba: u64) -> [u8; 3] {
-    let cylinder = lba / CHS_SECTORS_PER_CYLINDER as u64;
-
-    if cylinder > CHS_MAX_CYL as u64 {
-        // LBA beyond CHS addressable range for this geometry
-        return [0xFF, 0xFF, 0xFF];
+    let cyl = lba / SPC as u64;
+    if cyl > MAX_CYL as u64 {
+        return [0xFF; 3];
     }
-
-    let cylinder = cylinder as u32;
-    let remainder = (lba % CHS_SECTORS_PER_CYLINDER as u64) as u32;
-    let head = remainder / CHS_SPT;
-    let sector = (remainder % CHS_SPT) + 1;
-
-    let cylinder_hi = ((cylinder >> 8) & 0x03) as u8; // bits 8-9
-    let cylinder_lo = (cylinder & 0xFF) as u8;
-    let head_byte = head as u8;
-    let sector_byte = ((sector as u8) & 0x3F) | (cylinder_hi << 6);
-
-    [head_byte, sector_byte, cylinder_lo]
+    let cyl = cyl as u32;
+    let rem = (lba % SPC as u64) as u32;
+    let head = rem / SPT;
+    let sector = (rem % SPT) + 1;
+    let cyl_hi = ((cyl >> 8) & 0x03) as u8;
+    [
+        head as u8,
+        ((sector as u8) & 0x3F) | (cyl_hi << 6),
+        (cyl & 0xFF) as u8,
+    ]
 }
 
 #[repr(C, packed)]
@@ -76,120 +51,77 @@ impl Default for Mbr {
 
 impl Mbr {
     pub fn new() -> Self {
-        Mbr {
+        Self {
             boot_code: [0; 440],
             disk_signature: 0,
             reserved: 0,
-            partition_table: [MbrPartitionEntry::default(); 4],
+            partition_table: Default::default(),
             boot_signature: 0xAA55,
         }
     }
 
-    /// Serialize the MBR to bytes using explicit little-endian conversions.
-    /// This avoids `mem::transmute` which is unsafe and sensitive to
-    /// compiler padding / endianness differences.
     pub fn to_bytes(&self) -> [u8; 512] {
-        let mut bytes = [0u8; 512];
-        let mut offset = 0;
-
-        // Boot code: 440 bytes
-        bytes[offset..offset + 440].copy_from_slice(&self.boot_code);
-        offset += 440;
-
-        // Disk signature: u32 LE
-        bytes[offset..offset + 4].copy_from_slice(&self.disk_signature.to_le_bytes());
-        offset += 4;
-
-        // Reserved: u16 LE
-        bytes[offset..offset + 2].copy_from_slice(&self.reserved.to_le_bytes());
-        offset += 2;
-
-        // 4 partition entries (16 bytes each)
-        for entry in &self.partition_table {
-            bytes[offset] = entry.bootable;
-            bytes[offset + 1..offset + 4].copy_from_slice(&entry.starting_chs);
-            bytes[offset + 4] = entry.partition_type;
-            bytes[offset + 5..offset + 8].copy_from_slice(&entry.ending_chs);
-            bytes[offset + 8..offset + 12].copy_from_slice(&entry.starting_lba.to_le_bytes());
-            bytes[offset + 12..offset + 16].copy_from_slice(&entry.size_in_lba.to_le_bytes());
-            offset += 16;
+        let mut b = [0u8; 512];
+        b[..440].copy_from_slice(&self.boot_code);
+        b[440..444].copy_from_slice(&self.disk_signature.to_le_bytes());
+        b[444..446].copy_from_slice(&self.reserved.to_le_bytes());
+        let mut off = 446;
+        for e in &self.partition_table {
+            b[off] = e.bootable;
+            b[off + 1..off + 4].copy_from_slice(&e.starting_chs);
+            b[off + 4] = e.partition_type;
+            b[off + 5..off + 8].copy_from_slice(&e.ending_chs);
+            b[off + 8..off + 12].copy_from_slice(&e.starting_lba.to_le_bytes());
+            b[off + 12..off + 16].copy_from_slice(&e.size_in_lba.to_le_bytes());
+            off += 16;
         }
-
-        // Boot signature: u16 LE (0xAA55)
-        bytes[offset..offset + 2].copy_from_slice(&self.boot_signature.to_le_bytes());
-
-        bytes
+        b[510..512].copy_from_slice(&self.boot_signature.to_le_bytes());
+        b
     }
 
-    pub fn write_to<W: Write + Seek>(&self, writer: &mut W) -> io::Result<()> {
-        let bytes = self.to_bytes();
-        writer.write_all(&bytes)?;
-        Ok(())
+    pub fn write_to<W: Write + Seek>(&self, w: &mut W) -> io::Result<()> {
+        w.write_all(&self.to_bytes())
     }
 }
 
-/// Creates an MBR with xorriso-compatible hybrid partitions.
-/// `total_lbas` is in 512-byte sectors.
-///
-/// The MBR layout uses:
-///   - Partition 1: type 0xEE (GPT Protective), covers LBA 1 to end of disk.
-///     This is the standard protective MBR per UEFI spec §5.2.3.
-///     Ubuntu/xorriso both use 0xEE; some firmware (InsydeH2O, old AMI)
-///     checks for 0xEE to detect GPT layout.
-///   - Partition 2: type 0xEF (EFI System Partition), pointing to the ESP.
-///     Provides backward compatibility for firmware that reads MBR
-///     partitions directly (USB-HDD boot path).
-///
-/// Overlapping partitions are intentional and standard for hybrid MBR+GPT;
-/// the protective entry covers the whole disk while the ESP entry points
-/// to the EFI partition within it.
+fn set_part(pe: &mut MbrPartitionEntry, bootable: u8, ptype: u8, start_lba: u32, size_lba: u32) {
+    pe.bootable = bootable;
+    pe.partition_type = ptype;
+    pe.starting_lba = start_lba;
+    pe.size_in_lba = size_lba;
+    pe.starting_chs = lba_to_chs(start_lba as u64);
+    pe.ending_chs = lba_to_chs(start_lba as u64 + size_lba as u64 - 1);
+}
+
 pub fn create_mbr_for_gpt_hybrid(
     total_lbas: u32,
     is_isohybrid: bool,
-    esp_start_lba: Option<u32>,
-    esp_size_lba: Option<u32>,
+    esp_start: Option<u32>,
+    esp_size: Option<u32>,
 ) -> io::Result<Mbr> {
     let mut mbr = Mbr::new();
-
     if is_isohybrid {
-        // Protective MBR (type 0xEE) per UEFI spec §5.2.3.
-        // Covers the entire disk from LBA 1 (LBA 0 is the MBR itself).
-        // This tells UEFI firmware that the disk uses GPT partitioning.
-        mbr.partition_table[0].bootable = 0x00;
-        mbr.partition_table[0].partition_type = 0xEE; // GPT Protective (standard)
-        mbr.partition_table[0].starting_lba = 1;
-        mbr.partition_table[0].size_in_lba = total_lbas.saturating_sub(1);
-        mbr.partition_table[0].starting_chs = lba_to_chs(1);
-        let prot_end_lba = (total_lbas as u64).saturating_sub(1);
-        mbr.partition_table[0].ending_chs = lba_to_chs(prot_end_lba);
-
-        // EFI System Partition in MBR entry 1
-        // Provides a direct MBR pointer to the ESP for firmware that
-        // boots via USB-HDD and reads MBR partitions directly.
-        if let (Some(start), Some(size)) = (esp_start_lba, esp_size_lba)
-            && size > 0
-        {
-            let esp_start = start;
-            let esp_size = size;
-            mbr.partition_table[1].bootable = 0x00;
-            mbr.partition_table[1].partition_type = 0xEF; // EFI System Partition
-            mbr.partition_table[1].starting_lba = esp_start;
-            mbr.partition_table[1].size_in_lba = esp_size;
-            mbr.partition_table[1].starting_chs = lba_to_chs(esp_start as u64);
-            mbr.partition_table[1].ending_chs = lba_to_chs(
-                (esp_start as u64)
-                    .saturating_add(esp_size as u64)
-                    .saturating_sub(1),
-            );
+        set_part(
+            &mut mbr.partition_table[0],
+            0,
+            0xEE,
+            1,
+            total_lbas.saturating_sub(1),
+        );
+        if let (Some(s), Some(sz)) = (esp_start, esp_size) {
+            if sz > 0 {
+                set_part(&mut mbr.partition_table[1], 0, 0xEF, s, sz);
+            }
         }
     } else {
-        // Standard MBR for El Torito (if not isohybrid)
-        mbr.partition_table[0].bootable = 0x80; // Bootable
-        mbr.partition_table[0].partition_type = 0xEF; // EFI System Partition (placeholder)
-        mbr.partition_table[0].starting_lba = 1;
-        mbr.partition_table[0].size_in_lba = total_lbas.saturating_sub(1);
+        set_part(
+            &mut mbr.partition_table[0],
+            0x80,
+            0xEF,
+            1,
+            total_lbas.saturating_sub(1),
+        );
     }
-
     Ok(mbr)
 }
 
@@ -200,77 +132,46 @@ mod tests {
     use std::mem;
 
     #[test]
-    fn test_mbr_new() {
+    fn test_new() {
         let mbr = Mbr::new();
-        let boot_sig = mbr.boot_signature;
-        assert_eq!(boot_sig, 0xAA55);
+        assert_eq!({ mbr.boot_signature }, 0xAA55);
         assert_eq!(mbr.boot_code, [0; 440]);
-        let disk_sig = mbr.disk_signature;
-        assert_eq!(disk_sig, 0);
     }
 
     #[test]
-    fn test_create_mbr_isohybrid() -> io::Result<()> {
-        let total_lbas = 1000u32;
-        let esp_start = 4096u32;
-        let esp_size = 32768u32;
-        let mbr = create_mbr_for_gpt_hybrid(total_lbas, true, Some(esp_start), Some(esp_size))?;
-
-        // Part 1: type 0xEE (GPT Protective), covers disk from LBA 1
-        {
-            let bootable = mbr.partition_table[0].bootable;
-            let ptype = mbr.partition_table[0].partition_type;
-            let start = mbr.partition_table[0].starting_lba;
-            let size = mbr.partition_table[0].size_in_lba;
-            assert_eq!(bootable, 0x00);
-            assert_eq!(ptype, 0xEE);
-            assert_eq!(start, 1);
-            assert_eq!(size, total_lbas - 1);
-        }
-
-        // Part 2: EFI System Partition
-        {
-            let bootable = mbr.partition_table[1].bootable;
-            let ptype = mbr.partition_table[1].partition_type;
-            let start = mbr.partition_table[1].starting_lba;
-            let size = mbr.partition_table[1].size_in_lba;
-            assert_eq!(bootable, 0x00);
-            assert_eq!(ptype, 0xEF);
-            assert_eq!(start, esp_start);
-            assert_eq!(size, esp_size);
-        }
+    fn test_isohybrid() -> io::Result<()> {
+        let mbr = create_mbr_for_gpt_hybrid(1000, true, Some(4096), Some(32768))?;
+        let p0 = &mbr.partition_table[0];
+        assert_eq!({ p0.partition_type }, 0xEE);
+        assert_eq!({ p0.starting_lba }, 1);
+        assert_eq!({ p0.size_in_lba }, 999);
+        let p1 = &mbr.partition_table[1];
+        assert_eq!({ p1.partition_type }, 0xEF);
+        assert_eq!({ p1.starting_lba }, 4096);
+        assert_eq!({ p1.size_in_lba }, 32768);
         Ok(())
     }
 
     #[test]
-    fn test_create_mbr_no_isohybrid() -> io::Result<()> {
-        let total_lbas = 2000;
-        let mbr = create_mbr_for_gpt_hybrid(total_lbas, false, None, None)?;
-
-        let bootable = mbr.partition_table[0].bootable;
-        let ptype = mbr.partition_table[0].partition_type;
-        let start = mbr.partition_table[0].starting_lba;
-        let size = mbr.partition_table[0].size_in_lba;
-        assert_eq!(bootable, 0x80);
-        assert_eq!(ptype, 0xEF);
-        assert_eq!(start, 1);
-        assert_eq!(size, total_lbas - 1);
+    fn test_no_isohybrid() -> io::Result<()> {
+        let mbr = create_mbr_for_gpt_hybrid(2000, false, None, None)?;
+        let p0 = &mbr.partition_table[0];
+        assert_eq!({ p0.bootable }, 0x80);
+        assert_eq!({ p0.partition_type }, 0xEF);
+        assert_eq!({ p0.starting_lba }, 1);
+        assert_eq!({ p0.size_in_lba }, 1999);
         Ok(())
     }
 
     #[test]
-    fn test_mbr_write_to() -> io::Result<()> {
+    fn test_write() -> io::Result<()> {
         let mbr = Mbr::new();
-        let mut buffer = Cursor::new(Vec::new());
-        mbr.write_to(&mut buffer)?;
-
-        let bytes = buffer.into_inner();
-        assert_eq!(bytes.len(), mem::size_of::<Mbr>());
-        assert_eq!(bytes.len(), 512);
-
-        // Check the boot signature at the end
-        let signature = u16::from_le_bytes([bytes[510], bytes[511]]);
-        assert_eq!(signature, 0xAA55);
+        let mut c = Cursor::new(Vec::new());
+        mbr.write_to(&mut c)?;
+        let b = c.into_inner();
+        assert_eq!(b.len(), mem::size_of::<Mbr>());
+        assert_eq!(b.len(), 512);
+        assert_eq!(u16::from_le_bytes([b[510], b[511]]), 0xAA55);
         Ok(())
     }
 }

--- a/src/iso/volume_descriptor.rs
+++ b/src/iso/volume_descriptor.rs
@@ -1,55 +1,26 @@
-// isobemak/src/iso/volume_descriptor.rs
 use crate::iso::boot_catalog::LBA_BOOT_CATALOG;
 use crate::iso::dir_record::IsoDirEntry;
 use crate::utils::{ISO_SECTOR_SIZE, seek_to_lba};
 use std::fs::File;
 use std::io::{self, Seek, SeekFrom, Write};
 
-pub const ISO_VOLUME_DESCRIPTOR_TERMINATOR: u8 = 255;
-pub const ISO_VOLUME_DESCRIPTOR_PRIMARY: u8 = 1;
-pub const ISO_VOLUME_DESCRIPTOR_BOOT_RECORD: u8 = 0;
-pub const ISO_ID: &[u8] = b"CD001";
-pub const ISO_VERSION: u8 = 1;
-pub const PVD_VOLUME_ID_OFFSET: usize = 40;
-pub const PVD_TOTAL_SECTORS_OFFSET: usize = 80;
-pub const PVD_ROOT_DIR_RECORD_OFFSET: usize = 156;
-pub const PVD_VOL_SET_SIZE_OFFSET: usize = 120;
-pub const PVD_VOL_SEQ_NUM_OFFSET: usize = 124;
-pub const PVD_LOGICAL_BLOCK_SIZE_OFFSET: usize = 128;
-pub const PVD_PATH_TABLE_SIZE_OFFSET: usize = 132;
+const PVD_VOL_ID: usize = 40;
+const PVD_TOTAL_SEC: usize = 80;
+const PVD_ROOT_DIR: usize = 156;
+const PVD_VOL_SET_SIZE: usize = 120;
+const PVD_VOL_SEQ_NUM: usize = 124;
+const PVD_LOGICAL_BLOCK: usize = 128;
+const PVD_PATH_TABLE: usize = 132;
 
-/// A helper function to update two 4-byte fields at different offsets
-/// within a single ISO sector (2048 bytes).
-fn update_4byte_fields(
-    iso: &mut File,
-    base_lba: u32,
-    offset1: usize,
-    offset2: usize,
-    value: u32,
-) -> io::Result<()> {
-    let base_offset = base_lba as u64 * ISO_SECTOR_SIZE as u64;
-
-    iso.seek(SeekFrom::Start(base_offset + offset1 as u64))?;
-    iso.write_all(&value.to_le_bytes())?;
-
-    iso.seek(SeekFrom::Start(base_offset + offset2 as u64))?;
-    iso.write_all(&value.to_be_bytes())?;
-
-    Ok(())
-}
-
-/// Helper to write a value in both little-endian and big-endian to a buffer at given offset and length.
-fn write_dual_endian(buf: &mut [u8], offset: usize, value: u32, byte_len: usize) {
-    match byte_len {
-        2 => {
-            buf[offset..offset + 2].copy_from_slice(&(value as u16).to_le_bytes());
-            buf[offset + 2..offset + 4].copy_from_slice(&(value as u16).to_be_bytes());
-        }
-        4 => {
-            buf[offset..offset + 4].copy_from_slice(&value.to_le_bytes());
-            buf[offset + 4..offset + 8].copy_from_slice(&value.to_be_bytes());
-        }
-        _ => panic!("Unsupported byte length for dual endian write"),
+fn write_dual(buf: &mut [u8], off: usize, val: u32, len: usize) {
+    let le = val.to_le_bytes();
+    let be = val.to_be_bytes();
+    if len == 2 {
+        buf[off..off + 2].copy_from_slice(&le[..2]);
+        buf[off + 2..off + 4].copy_from_slice(&be[..2]);
+    } else {
+        buf[off..off + 4].copy_from_slice(&le);
+        buf[off + 4..off + 8].copy_from_slice(&be);
     }
 }
 
@@ -61,115 +32,68 @@ pub fn write_primary_volume_descriptor(
 ) -> io::Result<()> {
     seek_to_lba(iso, 16)?;
     let mut pvd = [0u8; ISO_SECTOR_SIZE];
-    pvd[0] = ISO_VOLUME_DESCRIPTOR_PRIMARY;
-    pvd[1..6].copy_from_slice(ISO_ID);
-    pvd[6] = ISO_VERSION;
+    pvd[0] = 1; // primary
+    pvd[1..6].copy_from_slice(b"CD001");
+    pvd[6] = 1;
 
-    let project_name = match volume_id {
-        None => b"ISOBEMAKI",
-        Some(id) => {
-            let bytes = id.as_bytes();
-            &bytes[..bytes.len().min(32)]
-        }
-    };
+    let name = volume_id.map_or(b"ISOBEMAKI" as &[u8], |id| {
+        &id.as_bytes()[..id.len().min(32)]
+    });
+    let mut vol = [b' '; 32];
+    vol[..name.len()].copy_from_slice(name);
+    pvd[PVD_VOL_ID..PVD_VOL_ID + 32].copy_from_slice(&vol);
 
-    let mut volume_id = [b' '; 32];
-    volume_id[..project_name.len()].copy_from_slice(project_name);
-    pvd[PVD_VOLUME_ID_OFFSET..PVD_VOLUME_ID_OFFSET + 32].copy_from_slice(&volume_id);
+    write_dual(&mut pvd, PVD_TOTAL_SEC, total_sectors, 4);
+    write_dual(&mut pvd, PVD_VOL_SET_SIZE, 1, 2);
+    write_dual(&mut pvd, PVD_VOL_SEQ_NUM, 1, 2);
+    write_dual(&mut pvd, PVD_LOGICAL_BLOCK, ISO_SECTOR_SIZE as u32, 2);
+    write_dual(&mut pvd, PVD_PATH_TABLE, 0, 4);
 
-    write_dual_endian(&mut pvd, PVD_TOTAL_SECTORS_OFFSET, total_sectors, 4);
-    write_dual_endian(&mut pvd, PVD_VOL_SET_SIZE_OFFSET, 1, 2);
-    write_dual_endian(&mut pvd, PVD_VOL_SEQ_NUM_OFFSET, 1, 2);
-    write_dual_endian(
-        &mut pvd,
-        PVD_LOGICAL_BLOCK_SIZE_OFFSET,
-        ISO_SECTOR_SIZE as u32,
-        2,
-    );
-    write_dual_endian(&mut pvd, PVD_PATH_TABLE_SIZE_OFFSET, 0, 4);
-
-    let root_entry_bytes = root_entry.to_bytes();
-    pvd[PVD_ROOT_DIR_RECORD_OFFSET..PVD_ROOT_DIR_RECORD_OFFSET + root_entry_bytes.len()]
-        .copy_from_slice(&root_entry_bytes);
-
-    // File Structure Version (ECMA-119 8.4.24): MUST be 1
+    let re = root_entry.to_bytes();
+    pvd[PVD_ROOT_DIR..PVD_ROOT_DIR + re.len()].copy_from_slice(&re);
     pvd[881] = 1;
-
-    // Volume Creation Date/Time (ECMA-119 8.4.26.1, offset 813, 17 bytes)
-    // All-zero is spec-legal but libisofs rejects year=0/month=0 as "damaged".
-    // ISO 9660 uses ASCII digit characters, NOT binary integers.
-    // Format: "2024010100000000" + GMT offset (1 byte signed int, 15-min units).
-    // 2024-01-01 00:00:00.00 GMT+0
-    {
-        let date: [u8; 17] = *b"2024010100000000\x00";
-        pvd[813..830].copy_from_slice(&date);
-    }
-
-    // Volume Modification Date/Time (ECMA-119 8.4.26.2, offset 830, 17 bytes)
-    // Same value as creation date.
-    {
-        let date: [u8; 17] = *b"2024010100000000\x00";
-        pvd[830..847].copy_from_slice(&date);
-    }
-
-    // Application Use area: zero-initialized per spec
-    // bytes 883-1395 are already 0 from `[0u8; ISO_SECTOR_SIZE]` initialization
-
-    iso.write_all(&pvd)?;
-
-    Ok(())
+    pvd[813..830].copy_from_slice(b"2024010100000000\x00");
+    pvd[830..847].copy_from_slice(b"2024010100000000\x00");
+    iso.write_all(&pvd)
 }
 
 pub fn update_total_sectors_in_pvd(iso: &mut File, total_sectors: u32) -> io::Result<()> {
-    update_4byte_fields(
-        iso,
-        16,
-        PVD_TOTAL_SECTORS_OFFSET,
-        PVD_TOTAL_SECTORS_OFFSET + 4,
-        total_sectors,
-    )
+    let base = 16 * ISO_SECTOR_SIZE as u64;
+    iso.seek(SeekFrom::Start(base + PVD_TOTAL_SEC as u64))?;
+    iso.write_all(&total_sectors.to_le_bytes())?;
+    iso.seek(SeekFrom::Start(base + PVD_TOTAL_SEC as u64 + 4))?;
+    iso.write_all(&total_sectors.to_be_bytes())
 }
 
-pub fn write_boot_record_volume_descriptor(
-    iso: &mut File,
-    boot_catalog_lba: u32,
-) -> io::Result<()> {
+fn write_boot_record_vd(iso: &mut File) -> io::Result<()> {
     seek_to_lba(iso, 17)?;
     let mut brvd = [0u8; ISO_SECTOR_SIZE];
-    brvd[0] = ISO_VOLUME_DESCRIPTOR_BOOT_RECORD;
-    brvd[1..6].copy_from_slice(ISO_ID);
-    brvd[6] = ISO_VERSION;
-    let spec_name = b"EL TORITO SPECIFICATION";
-    brvd[7..7 + spec_name.len()].copy_from_slice(spec_name);
-    brvd[71..75].copy_from_slice(&boot_catalog_lba.to_le_bytes());
-    iso.write_all(&brvd)?;
-    Ok(())
+    brvd[0] = 0;
+    brvd[1..6].copy_from_slice(b"CD001");
+    brvd[6] = 1;
+    brvd[7..30].copy_from_slice(b"EL TORITO SPECIFICATION");
+    brvd[71..75].copy_from_slice(&LBA_BOOT_CATALOG.to_le_bytes());
+    iso.write_all(&brvd)
 }
 
-pub fn write_volume_descriptor_terminator(iso: &mut File) -> io::Result<()> {
+fn write_terminator(iso: &mut File) -> io::Result<()> {
     seek_to_lba(iso, 18)?;
-    let mut term = [0u8; ISO_SECTOR_SIZE];
-    term[0] = ISO_VOLUME_DESCRIPTOR_TERMINATOR;
-    term[1..6].copy_from_slice(ISO_ID);
-    term[6] = ISO_VERSION;
-    iso.write_all(&term)?;
-    Ok(())
+    let mut t = [0u8; ISO_SECTOR_SIZE];
+    t[0] = 255;
+    t[1..6].copy_from_slice(b"CD001");
+    t[6] = 1;
+    iso.write_all(&t)
 }
 
-/// A combined function to write all necessary volume descriptors in sequence.
 pub fn write_volume_descriptors(
     iso: &mut File,
     volume_id: Option<&str>,
     total_sectors: u32,
     root_entry: &IsoDirEntry,
 ) -> io::Result<()> {
-    // Primary Volume Descriptor at LBA 16
     write_primary_volume_descriptor(iso, volume_id, total_sectors, root_entry)?;
-    // Boot Record Volume Descriptor at LBA 17, pointing to boot catalog at LBA 19
-    write_boot_record_volume_descriptor(iso, LBA_BOOT_CATALOG)?;
-    // Volume Descriptor Terminator at LBA 18
-    write_volume_descriptor_terminator(iso)?;
-    Ok(())
+    write_boot_record_vd(iso)?;
+    write_terminator(iso)
 }
 
 #[cfg(test)]
@@ -179,128 +103,67 @@ mod tests {
     use tempfile::NamedTempFile;
 
     fn read_sector(file: &mut File, lba: u32) -> io::Result<[u8; ISO_SECTOR_SIZE]> {
-        let mut buffer = [0u8; ISO_SECTOR_SIZE];
+        let mut buf = [0u8; ISO_SECTOR_SIZE];
         file.seek(SeekFrom::Start(lba as u64 * ISO_SECTOR_SIZE as u64))?;
-        file.read_exact(&mut buffer)?;
-        Ok(buffer)
+        file.read_exact(&mut buf)?;
+        Ok(buf)
     }
 
     #[test]
-    fn test_write_pvd() -> io::Result<()> {
-        let mut temp_file = NamedTempFile::new()?;
-        let root_entry = IsoDirEntry {
+    fn test_pvd() -> io::Result<()> {
+        let mut f = NamedTempFile::new()?;
+        let re = IsoDirEntry {
             lba: 20,
             size: 2048,
             flags: 2,
             name: ".",
         };
-        let total_sectors = 1000;
+        write_primary_volume_descriptor(f.as_file_mut(), None, 1000, &re)?;
+        let s = read_sector(f.as_file_mut(), 16)?;
+        assert_eq!(s[0], 1);
+        assert_eq!(&s[1..6], b"CD001");
+        assert_eq!(&s[PVD_TOTAL_SEC..PVD_TOTAL_SEC + 4], &1000u32.to_le_bytes());
+        let r = re.to_bytes();
+        assert_eq!(&s[PVD_ROOT_DIR..PVD_ROOT_DIR + r.len()], &r);
+        Ok(())
+    }
 
-        write_primary_volume_descriptor(temp_file.as_file_mut(), None, total_sectors, &root_entry)?;
-
-        let pvd_sector = read_sector(temp_file.as_file_mut(), 16)?;
-        assert_eq!(pvd_sector[0], ISO_VOLUME_DESCRIPTOR_PRIMARY);
-        assert_eq!(&pvd_sector[1..6], ISO_ID);
-        let mut expected_sectors = [0u8; 8];
-        expected_sectors[0..4].copy_from_slice(&total_sectors.to_le_bytes());
-        expected_sectors[4..8].copy_from_slice(&total_sectors.to_be_bytes());
+    #[test]
+    fn test_update_pvd() -> io::Result<()> {
+        let mut f = NamedTempFile::new()?;
+        let re = IsoDirEntry {
+            lba: 20,
+            size: 2048,
+            flags: 2,
+            name: ".",
+        };
+        write_primary_volume_descriptor(f.as_file_mut(), None, 1000, &re)?;
+        update_total_sectors_in_pvd(f.as_file_mut(), 2500)?;
+        let s = read_sector(f.as_file_mut(), 16)?;
         assert_eq!(
-            &pvd_sector[PVD_TOTAL_SECTORS_OFFSET..PVD_TOTAL_SECTORS_OFFSET + 8],
-            &expected_sectors
+            u32::from_le_bytes(s[PVD_TOTAL_SEC..PVD_TOTAL_SEC + 4].try_into().unwrap()),
+            2500
         );
-        let root_bytes = root_entry.to_bytes();
         assert_eq!(
-            &pvd_sector[PVD_ROOT_DIR_RECORD_OFFSET..PVD_ROOT_DIR_RECORD_OFFSET + root_bytes.len()],
-            &root_bytes
+            u32::from_be_bytes(s[PVD_TOTAL_SEC + 4..PVD_TOTAL_SEC + 8].try_into().unwrap()),
+            2500
         );
-
         Ok(())
     }
 
     #[test]
-    fn test_update_pvd_sectors() -> io::Result<()> {
-        let mut temp_file = NamedTempFile::new()?;
-        let root_entry = IsoDirEntry {
+    fn test_all_vds() -> io::Result<()> {
+        let mut f = NamedTempFile::new()?;
+        let re = IsoDirEntry {
             lba: 20,
             size: 2048,
             flags: 2,
             name: ".",
         };
-        write_primary_volume_descriptor(temp_file.as_file_mut(), None, 1000, &root_entry)?;
-
-        let new_total_sectors = 2500;
-        update_total_sectors_in_pvd(temp_file.as_file_mut(), new_total_sectors)?;
-
-        let pvd_sector = read_sector(temp_file.as_file_mut(), 16)?;
-        let read_sectors_le = u32::from_le_bytes(
-            pvd_sector[PVD_TOTAL_SECTORS_OFFSET..PVD_TOTAL_SECTORS_OFFSET + 4]
-                .try_into()
-                .unwrap(),
-        );
-        let read_sectors_be = u32::from_be_bytes(
-            pvd_sector[PVD_TOTAL_SECTORS_OFFSET + 4..PVD_TOTAL_SECTORS_OFFSET + 8]
-                .try_into()
-                .unwrap(),
-        );
-        assert_eq!(read_sectors_le, new_total_sectors);
-        assert_eq!(read_sectors_be, new_total_sectors);
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_write_brvd() -> io::Result<()> {
-        let mut temp_file = NamedTempFile::new()?;
-        let boot_catalog_lba = 99;
-        write_boot_record_volume_descriptor(temp_file.as_file_mut(), boot_catalog_lba)?;
-
-        let brvd_sector = read_sector(temp_file.as_file_mut(), 17)?;
-        assert_eq!(brvd_sector[0], ISO_VOLUME_DESCRIPTOR_BOOT_RECORD);
-        assert_eq!(&brvd_sector[1..6], ISO_ID);
-        assert_eq!(&brvd_sector[7..30], b"EL TORITO SPECIFICATION");
-        assert_eq!(&brvd_sector[71..75], &boot_catalog_lba.to_le_bytes());
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_write_terminator() -> io::Result<()> {
-        let mut temp_file = NamedTempFile::new()?;
-        write_volume_descriptor_terminator(temp_file.as_file_mut())?;
-
-        let term_sector = read_sector(temp_file.as_file_mut(), 18)?;
-        assert_eq!(term_sector[0], ISO_VOLUME_DESCRIPTOR_TERMINATOR);
-        assert_eq!(&term_sector[1..6], ISO_ID);
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_write_all_descriptors() -> io::Result<()> {
-        let mut temp_file = NamedTempFile::new()?;
-        let root_entry = IsoDirEntry {
-            lba: 20,
-            size: 2048,
-            flags: 2,
-            name: ".",
-        };
-        let total_sectors = 1234;
-
-        write_volume_descriptors(temp_file.as_file_mut(), None, total_sectors, &root_entry)?;
-
-        // Verify PVD
-        let pvd_sector = read_sector(temp_file.as_file_mut(), 16)?;
-        assert_eq!(pvd_sector[0], ISO_VOLUME_DESCRIPTOR_PRIMARY);
-
-        // Verify BRVD
-        let brvd_sector = read_sector(temp_file.as_file_mut(), 17)?;
-        assert_eq!(brvd_sector[0], ISO_VOLUME_DESCRIPTOR_BOOT_RECORD);
-        assert_eq!(&brvd_sector[71..75], &LBA_BOOT_CATALOG.to_le_bytes());
-
-        // Verify Terminator
-        let term_sector = read_sector(temp_file.as_file_mut(), 18)?;
-        assert_eq!(term_sector[0], ISO_VOLUME_DESCRIPTOR_TERMINATOR);
-
+        write_volume_descriptors(f.as_file_mut(), None, 1234, &re)?;
+        assert_eq!(read_sector(f.as_file_mut(), 16)?[0], 1);
+        assert_eq!(read_sector(f.as_file_mut(), 17)?[0], 0);
+        assert_eq!(read_sector(f.as_file_mut(), 18)?[0], 255);
         Ok(())
     }
 }


### PR DESCRIPTION
- Removed custom FAT32 image creation code in src/fat.rs; now using fatfs crate to create an in-memory FAT32 filesystem and format it.
- Eliminated unused regex dependency and its transitive deps (aho-corasick, memchr, regex-automata, regex-syntax).
- Simplified ISO volume descriptor writing by removing dual-endian helper function and reducing constant definitions.
- Updated tests to use fatfs structures instead of manual byte verification.

- [x] Refactoring

## Build / Test Results

```sh
$ cargo check     # ✅
$ cargo test      # ✅
```
---