### PR TITLE
Hotfix/#43

### DIFF
--- a/src/iso/builder.rs
+++ b/src/iso/builder.rs
@@ -21,7 +21,7 @@ use crate::iso::iso_writer::{
     copy_files, finalize_iso, write_boot_catalog_to_iso, write_descriptors, write_directories,
 };
 use crate::iso::layout_profile::{HiddenSectorMode, IsoLayoutProfile};
-use crate::iso::mbr::create_mbr_for_gpt_hybrid;
+use crate::iso::mbr::{create_mbr_esp_only, create_mbr_for_gpt_hybrid};
 use crate::iso::volume_descriptor::update_total_sectors_in_pvd;
 
 pub struct IsoBuilder {
@@ -188,15 +188,15 @@ impl IsoBuilder {
             };
 
         iso_file.seek(SeekFrom::Start(0))?;
-        create_mbr_for_gpt_hybrid(
-            total_for_mbr,
-            self.is_isohybrid,
-            esp_start_512,
-            esp_size_512,
-        )?
-        .write_to(iso_file)?;
-
         if self.profile.use_gpt {
+            create_mbr_for_gpt_hybrid(
+                total_for_mbr,
+                self.is_isohybrid,
+                esp_start_512,
+                esp_size_512,
+            )?
+            .write_to(iso_file)?;
+
             let mut parts = Vec::new();
             let start: u64 = 34;
             let end: u64 = total_512.saturating_sub(34);
@@ -226,6 +226,10 @@ impl IsoBuilder {
             if !parts.is_empty() {
                 write_gpt_structures(iso_file, total_512, &parts)?;
             }
+        } else {
+            // GPT off: MBR-only ESP layout (Ventoy-compatible)
+            create_mbr_esp_only(total_for_mbr, esp_start_512, esp_size_512)?
+                .write_to(iso_file)?;
         }
         iso_file.sync_data()?;
         Ok(())

--- a/src/iso/builder.rs
+++ b/src/iso/builder.rs
@@ -8,7 +8,7 @@ use crate::iso::boot_catalog::BootCatalogEntry;
 use crate::iso::boot_catalog::LBA_BOOT_CATALOG;
 use crate::iso::boot_info::BootInfo;
 use crate::iso::builder_utils::{
-    calculate_lbas, create_bios_boot_entry, create_uefi_boot_entry, create_uefi_esp_boot_entry,
+    calculate_lbas, create_bios_boot_entry, create_uefi_esp_boot_entry,
     ensure_directory_path, get_file_metadata, get_file_size_in_iso, get_lba_for_path,
 };
 use crate::iso::constants::{BACKUP_GPT_RESERVED_512, ISO_SECTOR_SIZE};
@@ -108,6 +108,9 @@ impl IsoBuilder {
         let mut entries = Vec::new();
         let bi = self.boot_info.as_ref();
 
+        // Check if BIOS boot will follow to determine more_follow flag
+        let bios_boot = bi.and_then(|b| b.bios_boot.as_ref()).is_some();
+
         // --- UEFI entries (always under a dedicated section header) ---
         let has_uefi = if let (Some(lba), Some(size)) = (esp_lba, esp_size_sectors) {
             if size > 0 {
@@ -123,7 +126,7 @@ impl IsoBuilder {
                     platform_id: BOOT_CATALOG_EFI_PLATFORM_ID,
                     boot_image_lba: 0,
                     boot_image_sectors: 0,
-                    entry_type: BootCatalogEntryType::SectionHeader { more_follow: false },
+                    entry_type: BootCatalogEntryType::SectionHeader { more_follow: bios_boot },
                 });
                 entries.push(create_uefi_esp_boot_entry(lba, size)?);
                 true
@@ -131,7 +134,25 @@ impl IsoBuilder {
                 false
             }
         } else if let Some(u) = bi.and_then(|b| b.uefi_boot.as_ref()) {
-            entries.push(create_uefi_boot_entry(&self.root, &u.destination_in_iso)?);
+            // Follow ESP pattern: use dedicated section header with zero boot_image_sectors
+            let lba = get_lba_for_path(&self.root, &u.destination_in_iso)?;
+            let size = get_file_size_in_iso(&self.root, &u.destination_in_iso)?.div_ceil(ISO_SECTOR_SIZE as u64) as u32;
+
+            // Initial / Default entry: sector_count MUST be 0 for
+            // no-emulation boot according to El Torito spec § 6.4.
+            entries.push(BootCatalogEntry {
+                platform_id: BOOT_CATALOG_EFI_PLATFORM_ID,
+                boot_image_lba: lba,
+                boot_image_sectors: 0,
+                entry_type: BootCatalogEntryType::BootEntry { bootable: true },
+            });
+            entries.push(BootCatalogEntry {
+                platform_id: BOOT_CATALOG_EFI_PLATFORM_ID,
+                boot_image_lba: 0,
+                boot_image_sectors: 0,
+                entry_type: BootCatalogEntryType::SectionHeader { more_follow: bios_boot },
+            });
+            entries.push(create_uefi_esp_boot_entry(lba, size)?);
             true
         } else {
             false

--- a/src/iso/builder.rs
+++ b/src/iso/builder.rs
@@ -108,9 +108,17 @@ impl IsoBuilder {
         let mut entries = Vec::new();
         let bi = self.boot_info.as_ref();
 
-        if let (Some(lba), Some(size)) = (esp_lba, esp_size_sectors) {
+        // --- UEFI entries (always under a dedicated section header) ---
+        let has_uefi = if let (Some(lba), Some(size)) = (esp_lba, esp_size_sectors) {
             if size > 0 {
-                entries.push(create_uefi_esp_boot_entry(lba, size)?);
+                // Initial / Default entry: sector_count MUST be 0 for
+                // no-emulation boot according to El Torito spec § 6.4.
+                entries.push(BootCatalogEntry {
+                    platform_id: BOOT_CATALOG_EFI_PLATFORM_ID,
+                    boot_image_lba: lba,
+                    boot_image_sectors: 0,
+                    entry_type: BootCatalogEntryType::BootEntry { bootable: true },
+                });
                 entries.push(BootCatalogEntry {
                     platform_id: BOOT_CATALOG_EFI_PLATFORM_ID,
                     boot_image_lba: 0,
@@ -118,11 +126,30 @@ impl IsoBuilder {
                     entry_type: BootCatalogEntryType::SectionHeader { more_follow: false },
                 });
                 entries.push(create_uefi_esp_boot_entry(lba, size)?);
+                true
+            } else {
+                false
             }
         } else if let Some(u) = bi.and_then(|b| b.uefi_boot.as_ref()) {
             entries.push(create_uefi_boot_entry(&self.root, &u.destination_in_iso)?);
-        }
+            true
+        } else {
+            false
+        };
+
+        // --- BIOS entry in its own section (must not be grouped under EFI) ---
         if let Some(b) = bi.and_then(|b| b.bios_boot.as_ref()) {
+            // A section header is required whenever platform-specific boot
+            // entries follow; without it (or when placed after an EFI section
+            // header) some firmware treats the BIOS entry as an EFI entry.
+            if has_uefi {
+                entries.push(BootCatalogEntry {
+                    platform_id: 0x00,
+                    boot_image_lba: 0,
+                    boot_image_sectors: 0,
+                    entry_type: BootCatalogEntryType::SectionHeader { more_follow: false },
+                });
+            }
             entries.push(create_bios_boot_entry(&self.root, &b.destination_in_iso)?);
         }
         Ok(entries)

--- a/src/iso/builder.rs
+++ b/src/iso/builder.rs
@@ -226,11 +226,13 @@ impl IsoBuilder {
             if !parts.is_empty() {
                 write_gpt_structures(iso_file, total_512, &parts)?;
             }
-        } else {
+        } else if self.profile.mbr_mode != crate::iso::layout_profile::MbrMode::None {
             // GPT off: MBR-only ESP layout (Ventoy-compatible)
             create_mbr_esp_only(total_for_mbr, esp_start_512, esp_size_512)?
                 .write_to(iso_file)?;
         }
+        // MbrMode::None → no MBR/GPT written at all.
+        // The FAT32 image starts at byte 0 (super-floppy style).
         iso_file.sync_data()?;
         Ok(())
     }

--- a/src/iso/builder.rs
+++ b/src/iso/builder.rs
@@ -21,7 +21,7 @@ use crate::iso::iso_writer::{
     copy_files, finalize_iso, write_boot_catalog_to_iso, write_descriptors, write_directories,
 };
 use crate::iso::layout_profile::{HiddenSectorMode, IsoLayoutProfile};
-use crate::iso::mbr::{create_mbr_esp_only, create_mbr_for_gpt_hybrid};
+use crate::iso::mbr::create_mbr_for_gpt_hybrid;
 use crate::iso::volume_descriptor::update_total_sectors_in_pvd;
 
 pub struct IsoBuilder {
@@ -226,13 +226,7 @@ impl IsoBuilder {
             if !parts.is_empty() {
                 write_gpt_structures(iso_file, total_512, &parts)?;
             }
-        } else if self.profile.mbr_mode != crate::iso::layout_profile::MbrMode::None {
-            // GPT off: MBR-only ESP layout (Ventoy-compatible)
-            create_mbr_esp_only(total_for_mbr, esp_start_512, esp_size_512)?
-                .write_to(iso_file)?;
         }
-        // MbrMode::None → no MBR/GPT written at all.
-        // The FAT32 image starts at byte 0 (super-floppy style).
         iso_file.sync_data()?;
         Ok(())
     }

--- a/src/iso/builder_utils.rs
+++ b/src/iso/builder_utils.rs
@@ -153,16 +153,13 @@ pub fn create_uefi_boot_entry(root: &IsoDirectory, path: &str) -> io::Result<Boo
     ))
 }
 
-pub fn create_uefi_esp_boot_entry(esp_lba: u32, esp_size: u32) -> io::Result<BootCatalogEntry> {
-    let sectors_512: u64 = esp_size as u64 * 4;
-    let sectors: u16 = if sectors_512 > u16::MAX as u64 {
-        0
-    } else {
-        sectors_512 as u16
-    };
+pub fn create_uefi_esp_boot_entry(esp_lba: u32, _esp_size: u32) -> io::Result<BootCatalogEntry> {
+    // No-emulation boot entries MUST have sector_count = 0 per El Torito
+    // spec § 6.4.  The actual image size is conveyed via the Section Header
+    // entry count field.
     Ok(mk_boot_entry(
         BOOT_CATALOG_EFI_PLATFORM_ID,
         esp_lba,
-        sectors,
+        0,
     ))
 }

--- a/src/iso/builder_utils.rs
+++ b/src/iso/builder_utils.rs
@@ -153,6 +153,16 @@ pub fn create_uefi_boot_entry(root: &IsoDirectory, path: &str) -> io::Result<Boo
     ))
 }
 
-pub fn create_uefi_esp_boot_entry(esp_lba: u32, _esp_size: u32) -> io::Result<BootCatalogEntry> {
-    Ok(mk_boot_entry(BOOT_CATALOG_EFI_PLATFORM_ID, esp_lba, 0))
+pub fn create_uefi_esp_boot_entry(esp_lba: u32, esp_size: u32) -> io::Result<BootCatalogEntry> {
+    let sectors_512: u64 = esp_size as u64 * 4;
+    let sectors: u16 = if sectors_512 > u16::MAX as u64 {
+        0
+    } else {
+        sectors_512 as u16
+    };
+    Ok(mk_boot_entry(
+        BOOT_CATALOG_EFI_PLATFORM_ID,
+        esp_lba,
+        sectors,
+    ))
 }

--- a/src/iso/layout_profile.rs
+++ b/src/iso/layout_profile.rs
@@ -23,6 +23,7 @@ pub enum EspMode {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MbrMode {
     HybridLinuxEsp,
+    EspOnly,
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HiddenSectorMode {
@@ -56,6 +57,45 @@ impl IsoLayoutProfile {
             esp_alignment_lba_512: 4096,
             mbr_mode: MbrMode::HybridLinuxEsp,
             hidden_sectors_mode: HiddenSectorMode::Zero,
+            uefi_boot_strategy: UefiBootStrategy::EspPartition,
+        }
+    }
+
+    /// Ventoy-compatible layout: GPT off, MBR-only ESP partition.
+    ///
+    /// Ventoy's default 2048-byte block mode cannot read GPT headers (they
+    /// reside at byte 512 = LBA 1 in 512-byte addressing, but Ventoy maps
+    /// LBA 1 → byte 2048).  This layout writes a plain MBR with type 0xEF
+    /// (ESP), which the UEFI partition driver *can* discover because the MBR
+    /// lives at byte 0 regardless of block size.
+    pub fn ventoy_compat() -> Self {
+        Self {
+            use_gpt: false,
+            eltorito_mode: ElToritoMode::Both,
+            esp_mode: EspMode::AppendedPartition,
+            esp_alignment_lba_512: 2048,
+            mbr_mode: MbrMode::EspOnly,
+            hidden_sectors_mode: HiddenSectorMode::PartitionOffset,
+            uefi_boot_strategy: UefiBootStrategy::EspPartition,
+        }
+    }
+
+    /// Flat MBR layout: no GPT, ESP partition starts at alignment (LBA 2048 or user-set).
+    ///
+    /// This maximizes Ventoy compatibility: the MBR lives at byte 0, GPT is absent,
+    /// and the FAT BPB's hidden-sectors field matches the partition start so the
+    /// UEFI partition driver can mount the filesystem regardless of block size.
+    ///
+    /// Use `esp_alignment_lba_512: 0` only if you know the ESP must start at
+    /// LBA 0 (e.g. for certain embedded or floppy-emulation scenarios).
+    pub fn flat() -> Self {
+        Self {
+            use_gpt: false,
+            eltorito_mode: ElToritoMode::Both,
+            esp_mode: EspMode::AppendedPartition,
+            esp_alignment_lba_512: 0,
+            mbr_mode: MbrMode::EspOnly,
+            hidden_sectors_mode: HiddenSectorMode::PartitionOffset,
             uefi_boot_strategy: UefiBootStrategy::EspPartition,
         }
     }

--- a/src/iso/layout_profile.rs
+++ b/src/iso/layout_profile.rs
@@ -24,6 +24,11 @@ pub enum EspMode {
 pub enum MbrMode {
     HybridLinuxEsp,
     EspOnly,
+    /// No MBR or GPT partition table at all — the FAT32 image starts at byte 0.
+    /// The whole block device is a single FAT32 volume ("super floppy" style).
+    /// This works with Ventoy only if it does NOT connect a partition driver.
+    /// Enable `write_mbr: false` in the builder when using this mode.
+    None,
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HiddenSectorMode {
@@ -96,6 +101,35 @@ impl IsoLayoutProfile {
             esp_alignment_lba_512: 0,
             mbr_mode: MbrMode::EspOnly,
             hidden_sectors_mode: HiddenSectorMode::PartitionOffset,
+            uefi_boot_strategy: UefiBootStrategy::EspPartition,
+        }
+    }
+
+    /// Ventoy super-floppy layout: no MBR, no GPT.
+    ///
+    /// The entire ISO9660 filesystem tail is preceded by a FAT32 image written
+    /// at byte 0 (LBA 0 in 512-byte parlance).  The FAT32 BPB at the very
+    /// first sector acts as a "super floppy" — the UEFI partition driver may
+    /// skip the absent partition table and mount the FAT volume directly.
+    ///
+    /// This layout gives the best chance on Ventoy + real hardware because
+    /// the FAT BPB lives at byte 0, which is always LBA 0 regardless of the
+    /// block size Ventoy uses.
+    ///
+    /// **Caveat**: Ventoy explicitly connects the Partition Driver via
+    /// `ventoy_connect_driver(gBlockData.Handle, L"Partition Driver")`,
+    /// so in practice the partition driver *must* see at least an MBR with a
+    /// type-0xEF entry for the ESP to be recognised.  Setting `mbr_mode`
+    /// to `None` disables MBR writing; you may need to patch Ventoy to
+    /// skip the partition-driver connection for such images.
+    pub fn ventoy_direct() -> Self {
+        Self {
+            use_gpt: false,
+            eltorito_mode: ElToritoMode::DirectEfiOnly,
+            esp_mode: EspMode::AppendedPartition,
+            esp_alignment_lba_512: 0,
+            mbr_mode: MbrMode::None,
+            hidden_sectors_mode: HiddenSectorMode::Zero,
             uefi_boot_strategy: UefiBootStrategy::EspPartition,
         }
     }

--- a/src/iso/layout_profile.rs
+++ b/src/iso/layout_profile.rs
@@ -23,12 +23,6 @@ pub enum EspMode {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MbrMode {
     HybridLinuxEsp,
-    EspOnly,
-    /// No MBR or GPT partition table at all — the FAT32 image starts at byte 0.
-    /// The whole block device is a single FAT32 volume ("super floppy" style).
-    /// This works with Ventoy only if it does NOT connect a partition driver.
-    /// Enable `write_mbr: false` in the builder when using this mode.
-    None,
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HiddenSectorMode {
@@ -66,71 +60,4 @@ impl IsoLayoutProfile {
         }
     }
 
-    /// Ventoy-compatible layout: GPT off, MBR-only ESP partition.
-    ///
-    /// Ventoy's default 2048-byte block mode cannot read GPT headers (they
-    /// reside at byte 512 = LBA 1 in 512-byte addressing, but Ventoy maps
-    /// LBA 1 → byte 2048).  This layout writes a plain MBR with type 0xEF
-    /// (ESP), which the UEFI partition driver *can* discover because the MBR
-    /// lives at byte 0 regardless of block size.
-    pub fn ventoy_compat() -> Self {
-        Self {
-            use_gpt: false,
-            eltorito_mode: ElToritoMode::Both,
-            esp_mode: EspMode::AppendedPartition,
-            esp_alignment_lba_512: 2048,
-            mbr_mode: MbrMode::EspOnly,
-            hidden_sectors_mode: HiddenSectorMode::PartitionOffset,
-            uefi_boot_strategy: UefiBootStrategy::EspPartition,
-        }
-    }
-
-    /// Flat MBR layout: no GPT, ESP partition starts at alignment (LBA 2048 or user-set).
-    ///
-    /// This maximizes Ventoy compatibility: the MBR lives at byte 0, GPT is absent,
-    /// and the FAT BPB's hidden-sectors field matches the partition start so the
-    /// UEFI partition driver can mount the filesystem regardless of block size.
-    ///
-    /// Use `esp_alignment_lba_512: 0` only if you know the ESP must start at
-    /// LBA 0 (e.g. for certain embedded or floppy-emulation scenarios).
-    pub fn flat() -> Self {
-        Self {
-            use_gpt: false,
-            eltorito_mode: ElToritoMode::Both,
-            esp_mode: EspMode::AppendedPartition,
-            esp_alignment_lba_512: 0,
-            mbr_mode: MbrMode::EspOnly,
-            hidden_sectors_mode: HiddenSectorMode::PartitionOffset,
-            uefi_boot_strategy: UefiBootStrategy::EspPartition,
-        }
-    }
-
-    /// Ventoy super-floppy layout: no MBR, no GPT.
-    ///
-    /// The entire ISO9660 filesystem tail is preceded by a FAT32 image written
-    /// at byte 0 (LBA 0 in 512-byte parlance).  The FAT32 BPB at the very
-    /// first sector acts as a "super floppy" — the UEFI partition driver may
-    /// skip the absent partition table and mount the FAT volume directly.
-    ///
-    /// This layout gives the best chance on Ventoy + real hardware because
-    /// the FAT BPB lives at byte 0, which is always LBA 0 regardless of the
-    /// block size Ventoy uses.
-    ///
-    /// **Caveat**: Ventoy explicitly connects the Partition Driver via
-    /// `ventoy_connect_driver(gBlockData.Handle, L"Partition Driver")`,
-    /// so in practice the partition driver *must* see at least an MBR with a
-    /// type-0xEF entry for the ESP to be recognised.  Setting `mbr_mode`
-    /// to `None` disables MBR writing; you may need to patch Ventoy to
-    /// skip the partition-driver connection for such images.
-    pub fn ventoy_direct() -> Self {
-        Self {
-            use_gpt: false,
-            eltorito_mode: ElToritoMode::DirectEfiOnly,
-            esp_mode: EspMode::AppendedPartition,
-            esp_alignment_lba_512: 0,
-            mbr_mode: MbrMode::None,
-            hidden_sectors_mode: HiddenSectorMode::Zero,
-            uefi_boot_strategy: UefiBootStrategy::EspPartition,
-        }
-    }
 }

--- a/src/iso/mbr.rs
+++ b/src/iso/mbr.rs
@@ -125,26 +125,6 @@ pub fn create_mbr_for_gpt_hybrid(
     Ok(mbr)
 }
 
-/// MBR with a single ESP (type 0xEF) partition, no GPT protective entry.
-/// This is the layout Ventoy expects: the partition driver reads the MBR
-/// successfully (it lives at byte 0, which is LBA 0 regardless of block size),
-/// finds type 0xEF, and mounts the EFI System Partition.
-pub fn create_mbr_esp_only(
-    total_lbas: u32,
-    esp_start: Option<u32>,
-    esp_size: Option<u32>,
-) -> io::Result<Mbr> {
-    let mut mbr = Mbr::new();
-    if let (Some(s), Some(sz)) = (esp_start, esp_size)
-        && sz > 0
-    {
-        set_part(&mut mbr.partition_table[0], 0x00, 0xEF, s, sz);
-    } else {
-        // Fallback: ESP covering the whole addressable space
-        set_part(&mut mbr.partition_table[0], 0x00, 0xEF, 1, total_lbas.saturating_sub(1));
-    }
-    Ok(mbr)
-}
 
 #[cfg(test)]
 mod tests {

--- a/src/iso/mbr.rs
+++ b/src/iso/mbr.rs
@@ -125,6 +125,27 @@ pub fn create_mbr_for_gpt_hybrid(
     Ok(mbr)
 }
 
+/// MBR with a single ESP (type 0xEF) partition, no GPT protective entry.
+/// This is the layout Ventoy expects: the partition driver reads the MBR
+/// successfully (it lives at byte 0, which is LBA 0 regardless of block size),
+/// finds type 0xEF, and mounts the EFI System Partition.
+pub fn create_mbr_esp_only(
+    total_lbas: u32,
+    esp_start: Option<u32>,
+    esp_size: Option<u32>,
+) -> io::Result<Mbr> {
+    let mut mbr = Mbr::new();
+    if let (Some(s), Some(sz)) = (esp_start, esp_size)
+        && sz > 0
+    {
+        set_part(&mut mbr.partition_table[0], 0x00, 0xEF, s, sz);
+    } else {
+        // Fallback: ESP covering the whole addressable space
+        set_part(&mut mbr.partition_table[0], 0x00, 0xEF, 1, total_lbas.saturating_sub(1));
+    }
+    Ok(mbr)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UEFI/BIOS boot catalog layout: emits an explicit UEFI no-emulation entry and proper EFI/BIO S section headers to prevent firmware misclassification.
  * Hybrid MBR write now only occurs when GPT mode is enabled, avoiding incorrect hybrid writes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->